### PR TITLE
Fix links in Cohen project labs

### DIFF
--- a/src/content/nwb-conversions/case-western-fox-lab.md
+++ b/src/content/nwb-conversions/case-western-fox-lab.md
@@ -3,7 +3,7 @@ lab: "Jessica Fox"
 institution: "Case Western Reserve University"
 description: "Developed NWB conversion tools for the Fox lab's research on Drosophila sensory systems. The pipeline standardizes high-speed video recordings, DeepLabCut output files, confocal imaging data, and intracellular electrophysiology recordings. These tools integrate stimulus traces and synchronization signals from Spike2, enabling researchers to study sensory processing across multiple modalities with precisely aligned data."
 tags: ["electrophysiology", "video", "behavioral tracking", "pose estimation"]
-github: "https://github.com/catalystneuro/fox-lab-to-nwb"
+github: "https://github.com/catalystneuro/cohen-u01-to-nwb"
 date: "2024"
 funded_project: "Drosophila Sensation U01"
 species: "Drosophila"

--- a/src/content/nwb-conversions/cornell-cohen-lab.md
+++ b/src/content/nwb-conversions/cornell-cohen-lab.md
@@ -3,7 +3,7 @@ lab: "Itai Cohen"
 institution: "Cornell University"
 description: "Developed NWB conversion tools for the Cohen lab's research on Drosophila behavior. The conversion pipeline standardizes high-resolution videos of behaving flies along with synchronized behavioral measurements stored in MATLAB formats. These tools enable researchers to correlate detailed fly movements with other physiological and sensory data."
 tags: ["behavioral tracking", "pose estimation", "video"]
-github: "https://github.com/catalystneuro/cohen-lab-to-nwb"
+github: "https://github.com/catalystneuro/cohen-u01-to-nwb"
 date: "2024"
 funded_project: "Drosophila Sensation U01"
 species: "Drosophila"

--- a/src/content/nwb-conversions/princeton-dickerson-lab.md
+++ b/src/content/nwb-conversions/princeton-dickerson-lab.md
@@ -3,7 +3,7 @@ lab: "Bradley Dickerson"
 institution: "Princeton University"
 description: "Developed NWB conversion tools for the Dickerson lab's research on Drosophila sensory processing. The pipeline standardizes two-photon imaging data from ThorLabs microscopes, neck muscle imaging, and high-speed video recordings. These tools integrate synchronization data from ThorSync to align neural and behavioral measurements, facilitating comprehensive analysis of sensory-motor transformations."
 tags: ["calcium imaging", "video", "behavioral tracking"]
-github: "https://github.com/catalystneuro/dickerson-lab-to-nwb"
+github: "https://github.com/catalystneuro/cohen-u01-to-nwb"
 date: "2024"
 funded_project: "Drosophila Sensation U01"
 species: "Drosophila"

--- a/src/content/nwb-conversions/ucsb-kim-lab.md
+++ b/src/content/nwb-conversions/ucsb-kim-lab.md
@@ -3,7 +3,7 @@ lab: "Sung Soo Kim"
 institution: "UC Santa Barbara"
 description: "Developed NWB conversion tools for the Kim lab's research on Drosophila visual processing. The pipeline standardizes two-photon imaging data, behavioral videos, and visual stimulus information. These tools integrate synchronization signals from MATLAB files and fluorescence traces from segmented regions of interest, facilitating analysis of neural responses to visual stimuli in relation to behavioral outputs."
 tags: ["calcium imaging", "video", "behavioral tracking", "visual processing"]
-github: "https://github.com/catalystneuro/kim-lab-to-nwb"
+github: "https://github.com/catalystneuro/cohen-u01-to-nwb"
 date: "2024"
 funded_project: "Drosophila Sensation U01"
 species: "Drosophila"

--- a/src/content/nwb-conversions/vanderbilt-suver-lab.md
+++ b/src/content/nwb-conversions/vanderbilt-suver-lab.md
@@ -3,7 +3,7 @@ lab: "Marie Suver"
 institution: "Vanderbilt University"
 description: "Developed NWB conversion tools for the Suver lab's research on Drosophila sensorimotor integration. The pipeline standardizes behavioral data from multiple cameras, wing beat tracking from microphone or tachometer recordings, antenna position tracking via DeepLabCut, and patch clamp recordings through Nidaq. These tools enable comprehensive analysis of neural activity in relation to complex fly behaviors."
 tags: ["electrophysiology", "behavioral tracking", "pose estimation", "video"]
-github: "https://github.com/catalystneuro/suver-lab-to-nwb"
+github: "https://github.com/catalystneuro/cohen-u01-to-nwb"
 date: "2024"
 funded_project: "Drosophila Sensation U01"
 species: "Drosophila"


### PR DESCRIPTION
As requested today I checked the recent conversions and I found that the links to the github repo are wrong. Maybe worth adding an instruction in the next batch addition to test links for non 404.