### PR TITLE
Add Schwerdt Lab

### DIFF
--- a/src/content/nwb-conversions/pitt-schwerdt-lab.md
+++ b/src/content/nwb-conversions/pitt-schwerdt-lab.md
@@ -1,0 +1,10 @@
+---
+lab: "Helen N. Schwerdt"
+institution: "University of Pittsburgh"
+description: "Developed NWB conversion tools for Schwerdt Lab's multi-modal neurochemical and electrophysiology datasets from rhesus monkeys. The pipeline supports conversion of fast-scan cyclic voltammetry (FSCV) signals, extracellular electrophysiology (Neuralynx) recordings from chronic striatal implants, spike times, and behavioral task events during reward-biased eye movement tasks."
+tags: ["fast-scan cyclic voltammetry", "micro-invasive neural implant", "dopamine recording", "striatum", "electrophysiology", "behavioral tracking"]
+github: "https://github.com/catalystneuro/schwerdt-lab-to-nwb"
+date: "2025-06"
+funded_project: "Michael J. Fox ASAP"
+species: Macaque
+---

--- a/src/content/nwb-conversions/pitt-schwerdt-lab.md
+++ b/src/content/nwb-conversions/pitt-schwerdt-lab.md
@@ -2,7 +2,7 @@
 lab: "Helen N. Schwerdt"
 institution: "University of Pittsburgh"
 description: "Developed NWB conversion tools for Schwerdt Lab's multi-modal neurochemical and electrophysiology datasets from rhesus monkeys. The pipeline supports conversion of fast-scan cyclic voltammetry (FSCV) signals, extracellular electrophysiology (Neuralynx) recordings from chronic striatal implants, spike times, and behavioral task events during reward-biased eye movement tasks."
-tags: ["fast-scan cyclic voltammetry", "micro-invasive neural implant", "dopamine recording", "striatum", "electrophysiology", "behavioral tracking"]
+tags: ["electrophysiology", "behavioral tracking"]
 github: "https://github.com/catalystneuro/schwerdt-lab-to-nwb"
 date: "2025-06"
 funded_project: "Michael J. Fox ASAP"


### PR DESCRIPTION
Add Schwerdt Lab to `src/content/nwb-conversions`:

-  Added [`src/content/nwb-conversions/pitt-schwerdt-lab.md`](diffhunk://#diff-d3287eececfa4b19a1af6850a024f22abbe5481f62cd3b3a5696f8729498b890R1-R10): contains metadata for the Schwerdt Lab project, including the lab and institution details, a description of the conversion pipeline, relevant tags, GitHub repository link, funding source, species studied, and the date of the project.