### PR TITLE
Fix Dan lab YAML parsing and add DANDI links

### DIFF
--- a/src/content/nwb-conversions/berkeley-dan-lab.md
+++ b/src/content/nwb-conversions/berkeley-dan-lab.md
@@ -1,7 +1,7 @@
 ---
 lab: Yang Dan
 institution: UC Berkeley
-description: Developing NWB conversion tools for the Dan lab's sleep-wake project. The pipeline standardizes multiple data streams including EEG, EMG, fiber photometry, optogenetic stimulation data, and behavioral videos. These tools enable comprehensive analysis of brain activity during sleep and wakefulness, facilitating data sharing through the DANDI Archive with example visualization notebooks for exploring the data relationships across modalities.
+description: "Developed NWB conversion tools for the Dan lab's sleep-wake project. The pipeline standardizes multiple data streams including EEG, EMG, fiber photometry, optogenetic stimulation data, behavioral videos, and DeepLabCut pose estimation. These tools enable comprehensive analysis of brain activity during sleep and wakefulness, facilitating data sharing through the DANDI Archive with example visualization notebooks for exploring the data relationships across modalities. This project culminated in two Dandisets: The first (#001617) focuses on the neural dynamics of sleep-wake regulation, as recorded by fiber photometry and the second (#001711) centers on the effects of optogenetic stimulation on behavioral outcomes as captured by video and pose estimation data."
 tags:
   - electrophysiology
   - fiber photometry
@@ -10,6 +10,11 @@ tags:
   - video
   - sleep research
 github: https://github.com/catalystneuro/dan-lab-to-nwb
+dandi:
+  - url: "https://dandiarchive.org/dandiset/001617"
+    name: "001617: Characterization of Sleep-Wake Patterns and Neural Activity in a Progressive Mouse Model of Parkinson's Disease"
+  - url: "https://dandiarchive.org/dandiset/001711"
+    name: "001711: Characterization of Sleep-Wake Patterns and Motor Behavior in a Progressive Mouse Model of Parkinson's Disease"
 date: "2024-12"
 funded_project: "Michael J. Fox ASAP"
 species: "Mouse"


### PR DESCRIPTION
## Summary
- Fixed YAML parsing error in Dan lab entry by quoting the description (colons in text were breaking the parser)
- Updated description with final project details including DeepLabCut pose estimation
- Added links to published Dandisets (#001617 and #001711)

## Test plan
- [ ] Verify site builds without YAML errors
- [ ] Confirm Dan lab entry renders correctly with DANDI links

🤖 Generated with [Claude Code](https://claude.com/claude-code)