### PR TITLE
Reorganize navbar into About / Software / Portfolio groups

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -18,25 +18,30 @@ export const Navigation = () => {
   };
 
   const menuItems = [
-    { label: "About", path: "/about" },
-    { label: "Team", path: "/team" },
+    {
+      label: "About",
+      items: [
+        { label: "About", path: "/about" },
+        { label: "Team", path: "/team" },
+        { label: "Openings", path: "/openings" },
+      ],
+    },
     {
       label: "Software",
       items: [
         { label: "NWB Software", path: "/nwb-software" },
         { label: "Analysis Software", path: "/analysis-software" },
-        { label: "NWB Conversions", path: "/nwb-conversions" },
       ],
     },
     {
       label: "Portfolio",
       items: [
+        { label: "NWB Conversions", path: "/nwb-conversions" },
         { label: "Funded Projects", path: "/funded-projects" },
         { label: "Publications", path: "/publications" },
       ],
     },
     { label: "Blog", path: "/blog" },
-    { label: "Openings", path: "/openings" },
     { label: "Contact", path: "/contact" },
   ];
 


### PR DESCRIPTION
Reorganizes the top-level navigation per the three agreed changes:

1. **Group "About" + "Team" + "Openings" under an About▾ dropdown** — collapses the two solo org links (and the low-traffic Openings link) into one menu.
2. **Move "NWB Conversions" from Software to Portfolio** — conversions are client deliverables, so they now sit alongside Funded Projects and Publications, matching the buyer's mental model.
3. **Software▾ now holds only products** — NWB Software and Analysis Software.

Result drops the top level from 7 items to 5:

```
About▾ · Software▾ · Portfolio▾ · Blog · Contact   [GH] [Request Consultation]

About▾      → About, Team, Openings
Software▾   → NWB Software, Analysis Software
Portfolio▾  → NWB Conversions, Funded Projects, Publications
```

Routes are unchanged — only the `menuItems` grouping in `Navigation.tsx` was edited. Mobile and desktop both render from this array, so both layouts update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)