### PR TITLE
Fix YAML parse error in Dan lab conversion frontmatter

### DIFF
--- a/src/content/nwb-conversions/berkeley-dan-lab.md
+++ b/src/content/nwb-conversions/berkeley-dan-lab.md
@@ -1,7 +1,7 @@
 ---
 lab: Yang Dan
 institution: UC Berkeley
-description: Developed NWB conversion tools for the Dan lab's sleep-wake project. The pipeline standardizes multiple data streams including EEG, EMG, fiber photometry, optogenetic stimulation data, behavioral videos, and DeepLabCut pose estimation. These tools enable comprehensive analysis of brain activity during sleep and wakefulness, facilitating data sharing through the DANDI Archive with example visualization notebooks for exploring the data relationships across modalities. This project culminated in two Dandisets: The first (#001617) focuses on the neural dynamics of sleep-wake regulation, as recorded by EEG, EMG, and fiber photometry, and probed by optogenetic stimulation. The second (#001711) centers on behavioral outcomes as captured by video and pose estimation data, alongside EEG and EMG recordings.
+description: "Developed NWB conversion tools for the Dan lab's sleep-wake project. The pipeline standardizes multiple data streams including EEG, EMG, fiber photometry, optogenetic stimulation data, behavioral videos, and DeepLabCut pose estimation. These tools enable comprehensive analysis of brain activity during sleep and wakefulness, facilitating data sharing through the DANDI Archive with example visualization notebooks for exploring the data relationships across modalities. This project culminated in two Dandisets: The first (#001617) focuses on the neural dynamics of sleep-wake regulation, as recorded by EEG, EMG, and fiber photometry, and probed by optogenetic stimulation. The second (#001711) centers on behavioral outcomes as captured by video and pose estimation data, alongside EEG and EMG recordings."
 tags:
   - electrophysiology
   - fiber photometry


### PR DESCRIPTION
The unquoted `description` value contains a colon ("two Dandisets: The first...") which front-matter's YAML parser interprets as a mapping key, throwing "incomplete explicit mapping pair" at runtime and breaking the NWB Conversions page on the live site.

Wrap the description in double quotes so the colon is treated as literal text. A prior fix (482533a) was lost when an old copy of this file was reintroduced via a later merge.