### PR TITLE
Add ndx-fiber-photometry to Neurodata Extensions

### DIFF
--- a/src/content/software/ndx-fiber-photometry.md
+++ b/src/content/software/ndx-fiber-photometry.md
@@ -1,0 +1,7 @@
+---
+name: NDX Fiber Photometry
+description: NWB extension for storing fiber photometry data. Provides neurodata types to capture the full experimental setup—including excitation sources, photodetectors, optical fibers, dichroic mirrors, and indicators—alongside the recorded fluorescence response series, enabling standardized and reproducible representation of fiber photometry experiments.
+status: Active
+type: extension
+github: https://github.com/catalystneuro/ndx-fiber-photometry
+---


### PR DESCRIPTION
Adds the [ndx-fiber-photometry](https://github.com/catalystneuro/ndx-fiber-photometry) extension to the **Neurodata Extensions** section of the NWB Software page.

New content file `src/content/software/ndx-fiber-photometry.md` (`type: extension`), which the page renders automatically via `loadSoftware()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)