### PR TITLE
Add Documentation & Guides index page at /guides

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import FundedProject from "./pages/FundedProject";
 import Publications from "./pages/Publications";
 import Contact from "./pages/Contact";
 import Guide from "./pages/Guide";
+import Guides from "./pages/Guides";
 import Consultation from "./pages/Consultation";
 import NotFound from "./pages/NotFound";
 import { blogPosts } from "./utils/blogLoader";
@@ -121,6 +122,11 @@ export const routes: RouteRecord[] = [
       },
       { path: "success", element: <Success /> },
       { path: "contact", element: <Contact />, handle: { title: "Contact" } },
+      {
+        path: "guides",
+        element: <Guides />,
+        handle: { title: "Documentation & Guides" },
+      },
       {
         path: "guides/:id",
         element: <Guide />,

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -31,6 +31,7 @@ export const Navigation = () => {
       items: [
         { label: "NWB Software", path: "/nwb-software" },
         { label: "Analysis Software", path: "/analysis-software" },
+        { label: "Guides", path: "/guides" },
       ],
     },
     {

--- a/src/content/software/globus-guide.md
+++ b/src/content/software/globus-guide.md
@@ -2,7 +2,7 @@
 name: "Sharing Data with CatalystNeuro"
 description: "Instructions for uploading your data to our size-unrestricted Google Drive folder using Globus"
 type: "guide"
-docs: "/guides/globus-guide.md"
+docs: "/guides/globus-guide"
 ---
 
 #### Thank you for sharing your data with the CatalystNeuro team!

--- a/src/content/software/nwb-engagement-guide.md
+++ b/src/content/software/nwb-engagement-guide.md
@@ -2,7 +2,7 @@
 name: "NWB Adoption Engagement Guide"
 description: "Guide for labs working with CatalystNeuro on NWB data conversion projects"
 type: "guide"
-docs: "/guides/nwb-engagement-guide.md"
+docs: "/guides/nwb-engagement-guide"
 ---
 
 #### Welcome to your NWB adoption engagement with CatalystNeuro!

--- a/src/pages/Guides.tsx
+++ b/src/pages/Guides.tsx
@@ -1,0 +1,45 @@
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ExternalLink } from "lucide-react";
+import { Link } from "react-router-dom";
+import { loadSoftware } from "@/utils/contentLoader";
+import PageLayout from "@/components/PageLayout";
+
+const Guides = () => {
+  const guides = loadSoftware().filter((software) => software.type === "guide");
+
+  return (
+    <PageLayout
+      title="Documentation & Guides"
+      subtitle="Step-by-step guides and reference documentation for working with CatalystNeuro and the NWB ecosystem."
+    >
+      <div className="grid gap-8 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
+        {guides.map((guide) => (
+          <Card
+            key={guide.name}
+            className="flex flex-col hover:shadow-lg transition-shadow backdrop-blur-sm bg-white/80 border-primary/10 hover:border-primary/30"
+          >
+            <CardHeader>
+              <CardTitle className="text-2xl">{guide.name}</CardTitle>
+            </CardHeader>
+            <CardContent className="flex-grow">
+              <CardDescription className="text-secondary/75 text-base">
+                {guide.description}
+              </CardDescription>
+            </CardContent>
+            <CardFooter>
+              <Button variant="outline" size="sm" asChild>
+                <Link to={guide.docs} className="flex items-center">
+                  <ExternalLink className="w-4 h-4 mr-2" />
+                  View Guide
+                </Link>
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+    </PageLayout>
+  );
+};
+
+export default Guides;

--- a/src/pages/NWBSoftware.tsx
+++ b/src/pages/NWBSoftware.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Github, ExternalLink } from "lucide-react";
+import { Github, ExternalLink, ArrowRight } from "lucide-react";
 import { Link } from "react-router-dom";
 import { loadSoftware } from "@/utils/contentLoader";
 import PageLayout from "@/components/PageLayout";
@@ -105,36 +105,17 @@ const NWBSoftware = () => {
         </div>
 
         <div>
-          <h2 className="text-3xl font-bold mb-6">Documentation & Guides</h2>
-          <div className="grid gap-8 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
-            {softwareList
-              .filter(software => software.type === 'guide')
-              .map((software) => (
-                <Card key={software.name} className="flex flex-col hover:shadow-lg transition-shadow backdrop-blur-sm bg-white/80 border-primary/10 hover:border-primary/30">
-                  <CardHeader>
-                    <div className="flex justify-between items-start">
-                      <div>
-                        <CardTitle className="text-2xl">{software.name}</CardTitle>
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="flex-grow">
-                    <p className="text-secondary/75">{software.description}</p>
-                  </CardContent>
-                  <CardFooter>
-                    <Button variant="outline" size="sm" asChild>
-                      <Link
-                        to={software.docs}
-                        className="flex items-center"
-                      >
-                        <ExternalLink className="w-4 h-4 mr-2" />
-                        View Guide
-                      </Link>
-                    </Button>
-                  </CardFooter>
-                </Card>
-              ))}
-          </div>
+          <h2 className="text-3xl font-bold mb-4">Documentation & Guides</h2>
+          <p className="text-secondary/75 mb-6 max-w-2xl">
+            Step-by-step guides for sharing data with us and working through an NWB
+            adoption engagement.
+          </p>
+          <Button variant="outline" asChild>
+            <Link to="/guides" className="flex items-center">
+              See all guides
+              <ArrowRight className="w-4 h-4 ml-2" />
+            </Link>
+          </Button>
         </div>
       </div>
     </PageLayout>


### PR DESCRIPTION
Promotes "Documentation & Guides" out of the bottom of the NWB Software page into its own discoverable home, as discussed.

## Changes
- **New `/guides` index page** listing all `type: "guide"` content as cards (reuses the existing card layout).
- **Navbar:** added **Guides** to the `Software▾` dropdown → `NWB Software · Analysis Software · Guides`.
- **`/nwb-software`:** replaced the inline guides grid with a lightweight **"See all guides →"** pointer, so people browsing tools still find the docs but `/guides` is the canonical home.
- **Cleaned guide URLs:** dropped the `.md` suffix from the `docs` links (`/guides/globus-guide.md` → `/guides/globus-guide`) so they match the slugs `vite-react-ssg` prerenders. Previously the links pointed at a URL that wasn't statically generated.

## Verification
- `npm run build` → `/guides` prerenders, and each guide page prerenders at its linked URL (`dist/guides/globus-guide/index.html`, `dist/guides/nwb-engagement-guide/index.html`). Index content and clean links confirmed in the output HTML; page title is "Documentation & Guides — CatalystNeuro".
- `vitest run` → 54 passing. Lint clean (only the pre-existing fast-refresh warning on `App.tsx`).

## Note
Only 2 guides exist today, so this is the right-sized step (Software-dropdown placement). If the guide library grows substantially later, the next move would be a dedicated `Resources▾` dropdown grouping Guides + Blog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)