### PR TITLE
P0 fixes: remove leaked Netlify token + per-page canonical URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,17 +8,12 @@
     <meta name="keywords" content="neurophysiology, NWB, Neurodata Without Borders, DANDI Archive, spike sorting, neuroscience data, open science, data standardization" />
 
     <!--
-      Per-route <title>, description, and Open Graph / Twitter tags are rendered
-      at build time by the Seo component (src/components/Seo.tsx) via
-      react-helmet-async. Keep page-specific SEO there, not here, to avoid
-      duplicate tags in the prerendered HTML.
+      Per-route <title>, description, canonical, and Open Graph / Twitter tags
+      are rendered at build time by the Seo component (src/components/Seo.tsx)
+      via vite-react-ssg's <Head>. Keep page-specific SEO there, not here, to
+      avoid duplicate tags in the prerendered HTML.
     -->
-    <meta property="og:url" content="https://catalystneuro.com/" />
-    <meta name="twitter:url" content="https://catalystneuro.com/" />
 
-    <!-- Canonical URL -->
-    <link rel="canonical" href="https://catalystneuro.com/" />
-    
     <!-- Additional SEO -->
     <meta name="robots" content="index, follow" />
     <meta name="theme-color" content="#1466A7" />

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,6 +32,3 @@
   for = "/images/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000"
-
-[build.environment]
-  NETLIFY_ACCESS_TOKEN = "nfp_rpNQC9Tf9Vr8kBP3L3ZDGZfvRkSZdUCD13a4"

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,4 +1,5 @@
 import { Head } from "vite-react-ssg";
+import { useLocation } from "react-router-dom";
 
 export interface SeoProps {
   title?: string;
@@ -8,10 +9,19 @@ export interface SeoProps {
 }
 
 const SITE_NAME = "CatalystNeuro";
+const SITE_URL = "https://catalystneuro.com";
 const DEFAULT_TITLE = `${SITE_NAME} - Neurophysiology Data & Software Solutions`;
 const DEFAULT_DESCRIPTION =
   "CatalystNeuro empowers neuroscience labs with data standardization, NWB conversions, spike sorting pipelines, and open-source software tools for neurophysiology research.";
 const DEFAULT_IMAGE = "/social-card.png";
+
+// Netlify's pretty-URL handling 301s interior pages to the trailing-slash
+// form, so canonicals must use it too or they point at a redirect.
+const canonicalUrl = (pathname: string) =>
+  `${SITE_URL}${pathname.endsWith("/") ? pathname : `${pathname}/`}`;
+
+const absoluteUrl = (pathOrUrl: string) =>
+  pathOrUrl.startsWith("http") ? pathOrUrl : `${SITE_URL}${pathOrUrl}`;
 
 /**
  * Per-route document head, rendered through react-helmet-async (via
@@ -29,21 +39,26 @@ export const Seo = ({
   type = "website",
 }: SeoProps) => {
   const fullTitle = title ? `${title} — ${SITE_NAME}` : DEFAULT_TITLE;
+  const url = canonicalUrl(useLocation().pathname);
+  const imageUrl = absoluteUrl(image);
   return (
     <Head>
       <title>{fullTitle}</title>
       <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
 
       <meta property="og:type" content={type} />
       <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:url" content={url} />
       <meta property="og:title" content={fullTitle} />
       <meta property="og:description" content={description} />
-      <meta property="og:image" content={image} />
+      <meta property="og:image" content={imageUrl} />
 
       <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:url" content={url} />
       <meta name="twitter:title" content={fullTitle} />
       <meta name="twitter:description" content={description} />
-      <meta name="twitter:image" content={image} />
+      <meta name="twitter:image" content={imageUrl} />
     </Head>
   );
 };


### PR DESCRIPTION
## Summary

Two critical fixes found during a site audit:

### 1. Remove leaked Netlify access token from `netlify.toml`
A `NETLIFY_ACCESS_TOKEN` was committed under `[build.environment]` in Jan 2025. The token is **already dead** (Netlify API returns 401 for it — likely auto-revoked via GitHub secret scanning), and nothing in the codebase reads it (the newsletter function only uses the Netlify-provided `URL` env var), so this is pure cleanup with no functional impact.

### 2. Per-page canonical and og:url
`index.html` hardcoded `<link rel="canonical">`, `og:url`, and `twitter:url` all pointing at the homepage, and `Seo.tsx` never overrode them — so **every prerendered page declared the homepage as its canonical URL**, telling search engines that all interior pages (team, blog posts, all 61 NWB conversion pages, funded projects) are duplicates of the homepage.

`Seo.tsx` now derives the canonical/og:url from the current route, using the trailing-slash form to match Netlify's pretty-URL 301 redirects. Since every page (static and dynamic) renders through the shared `Seo` component, this also absolutizes `og:image`/`twitter:image` URLs, which social scrapers (Slack, LinkedIn, Facebook) require — share cards were previously broken.

## Verification

- Rebuilt with `npm run build` and spot-checked `dist/` output: `dist/team/index.html` → `https://catalystneuro.com/team/`, each blog post gets its own URL, `og:image` absolute everywhere.
- All 54 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)