### PR TITLE
Generate sitemap.xml at build time and add robots.txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "dev": "vite",
     "copy-assets": "node scripts/copy-assets.js",
-    "build": "vite-react-ssg build && npm run copy-assets",
-    "build:dev": "vite-react-ssg build --mode development && npm run copy-assets",
+    "generate-sitemap": "node scripts/generate-sitemap.js",
+    "build": "vite-react-ssg build && npm run copy-assets && npm run generate-sitemap",
+    "build:dev": "vite-react-ssg build --mode development && npm run copy-assets && npm run generate-sitemap",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /success/
+
+Sitemap: https://catalystneuro.com/sitemap.xml

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Generates dist/sitemap.xml after the build by walking the prerendered
+// dist/**/index.html files, so the sitemap always matches the routes
+// vite-react-ssg actually emitted. URLs use the trailing-slash form to match
+// Netlify's pretty-URL redirects (and the canonicals set by Seo.tsx).
+
+const SITE_URL = 'https://catalystneuro.com';
+
+// Pages that exist but shouldn't be crawled (also disallowed in robots.txt).
+const EXCLUDED_PATHS = ['/success/'];
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const distDir = path.join(__dirname, '..', 'dist');
+
+const findPages = (dir) => {
+  const pages = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      pages.push(...findPages(full));
+    } else if (entry.name === 'index.html') {
+      const rel = path.relative(distDir, dir).split(path.sep).join('/');
+      pages.push(rel === '' ? '/' : `/${rel}/`);
+    }
+  }
+  return pages;
+};
+
+const pages = findPages(distDir)
+  .filter((p) => !EXCLUDED_PATHS.includes(p))
+  .sort();
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${pages.map((p) => `  <url><loc>${SITE_URL}${p}</loc></url>`).join('\n')}
+</urlset>
+`;
+
+fs.writeFileSync(path.join(distDir, 'sitemap.xml'), xml);
+console.log(`Generated dist/sitemap.xml with ${pages.length} URLs`);


### PR DESCRIPTION
## Summary

The site had neither a sitemap nor robots.txt — `catalystneuro.com/sitemap.xml` and `/robots.txt` currently serve the SPA homepage HTML (with a 200 status) via the `/* -> /index.html` catch-all redirect, so search engines have no crawl map for the 50+ content pages (blog, NWB conversions, funded projects, guides).

- **`scripts/generate-sitemap.js`** runs after the build and walks the prerendered `dist/**/index.html` files, so the sitemap always matches the routes vite-react-ssg actually emitted — no separate route list to keep in sync. Currently 53 URLs. Uses trailing-slash URLs to match Netlify's pretty-URL redirects (and the per-page canonicals from #65).
- **`public/robots.txt`** allows everything except `/success/` (the form-submission landing page, also excluded from the sitemap) and points at the sitemap.
- Wired into both `build` and `build:dev` in `package.json`.

Real files take precedence over the non-forced catch-all redirect on Netlify, so both will be served correctly once deployed.

## Verification

Ran `npm run build`: `dist/sitemap.xml` generated with 53 URLs (`/success/` excluded), `dist/robots.txt` present via `public/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)