### PR TITLE
Add blog post introducing zarr-matlab

### DIFF
--- a/images/blog/zarr-matlab-banner.svg
+++ b/images/blog/zarr-matlab-banner.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 400" width="1200" height="400" role="img" aria-label="zarr-matlab: Zarr v3, natively in MATLAB">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="hsl(230 45% 14%)"/>
+      <stop offset="55%" stop-color="hsl(220 55% 20%)"/>
+      <stop offset="100%" stop-color="hsl(24 70% 30%)"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="84%" cy="20%" r="55%">
+      <stop offset="0%" stop-color="hsl(24 90% 55%)" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="hsl(24 90% 55%)" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="400" fill="url(#bg)"/>
+  <rect width="1200" height="400" fill="url(#glow)"/>
+
+  <!-- chunked-array grid motif: an N-D array split into indexable chunks -->
+  <g transform="translate(770 60)" opacity="0.95">
+    <g stroke="white" stroke-opacity="0.35" stroke-width="2" fill="none">
+      <rect x="0" y="0" width="320" height="260" rx="6"/>
+    </g>
+    <g>
+      <!-- chunk grid -->
+      <g fill="hsl(24 85% 60%)" fill-opacity="0.85">
+        <rect x="6" y="6" width="72" height="60" rx="3"/>
+        <rect x="86" y="6" width="72" height="60" rx="3" fill="hsl(203 79% 62%)"/>
+        <rect x="166" y="6" width="72" height="60" rx="3" fill="hsl(24 85% 60%)"/>
+        <rect x="246" y="6" width="68" height="60" rx="3" fill="hsl(203 79% 62%)"/>
+
+        <rect x="6" y="72" width="72" height="60" rx="3" fill="hsl(203 79% 62%)"/>
+        <rect x="86" y="72" width="72" height="60" rx="3" fill="white" fill-opacity="0.55"/>
+        <rect x="166" y="72" width="72" height="60" rx="3" fill="hsl(203 79% 62%)"/>
+        <rect x="246" y="72" width="68" height="60" rx="3" fill="hsl(24 85% 60%)"/>
+
+        <rect x="6" y="138" width="72" height="60" rx="3" fill="hsl(24 85% 60%)"/>
+        <rect x="86" y="138" width="72" height="60" rx="3" fill="hsl(203 79% 62%)"/>
+        <rect x="166" y="138" width="72" height="60" rx="3" fill="white" fill-opacity="0.35"/>
+        <rect x="246" y="138" width="68" height="60" rx="3" fill="hsl(203 79% 62%)"/>
+
+        <rect x="6" y="204" width="72" height="50" rx="3" fill="hsl(203 79% 62%)"/>
+        <rect x="86" y="204" width="72" height="50" rx="3" fill="hsl(24 85% 60%)"/>
+        <rect x="166" y="204" width="72" height="50" rx="3" fill="hsl(203 79% 62%)"/>
+        <rect x="246" y="204" width="68" height="50" rx="3" fill="white" fill-opacity="0.5"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- text block -->
+  <g font-family="Inter, Segoe UI, Helvetica, Arial, sans-serif">
+    <text x="80" y="150" fill="white" font-size="72" font-weight="700">zarr-matlab</text>
+    <text x="82" y="203" fill="hsl(30 90% 78%)" font-size="30" font-weight="600">Zarr v3, natively in MATLAB</text>
+    <text x="82" y="248" fill="white" fill-opacity="0.8" font-size="22" font-weight="400">Free, open-source, pure-MATLAB implementation</text>
+    <text x="82" y="284" fill="white" fill-opacity="0.6" font-size="20" font-weight="400">CatalystNeuro</text>
+  </g>
+</svg>

--- a/src/content/blog/introducing-zarr-matlab.md
+++ b/src/content/blog/introducing-zarr-matlab.md
@@ -1,0 +1,56 @@
+---
+title: "Introducing zarr-matlab: Zarr v3, Natively in MATLAB"
+date: "2026-07-03"
+description: "zarr-matlab is a free, open-source, pure-MATLAB implementation of the Zarr v3 specification, bringing chunked, compressed, cloud-friendly N-dimensional arrays to MATLAB with interoperability tested against zarr-python on every commit."
+image: "/images/blog/zarr-matlab-banner.svg"
+readTime: "5 min read"
+keywords: ["zarr-matlab", "Zarr", "MATLAB", "NWB", "cloud computing", "scientific data", "open source", "hdmf-zarr", "matzarr"]
+---
+
+# Introducing zarr-matlab: Zarr v3, Natively in MATLAB
+
+Modern scientific data lives in the cloud, and the format it increasingly lives in is [Zarr](https://zarr.dev): chunked, compressed N-dimensional arrays designed so you can read the piece you need instead of downloading the file you don't. Zarr has first-class implementations in Python, Rust, C++, Julia, and JavaScript. MATLAB — still the daily driver for a huge share of working scientists — has been the conspicuous gap: MathWorks' built-in support covers only the older v2 format.
+
+Today we're releasing **[zarr-matlab](https://github.com/catalystneuro/zarr-matlab)**, a free, open-source, pure-MATLAB implementation of the Zarr v3 specification.
+
+## What it does
+
+```matlab
+% Create a compressed, chunked array — and index it like any MATLAB matrix
+z = zarr.create("weather.zarr", [720 1440], "single", ...
+    Path="temp", ChunkShape=[180 360], ...
+    Codecs={zarr.codecs.ZstdCodec(5)}, FillValue=single(NaN));
+z(:, :) = mydata;
+block = z(1:100, end-99:end);     % reads only the chunks it touches
+
+% Open data written by zarr-python, xarray, or any v3 implementation
+g = zarr.open("https://example.org/climate.zarr");   % read-only over HTTP
+tile = g.item("precipitation").read([1 1], [512 512]);
+```
+
+The feature list is the full v3 spec:
+
+- **Every data type**: integers, floats (including float16), complex, variable-length strings, and datetime64 — stored losslessly
+- **Real compression**: zstd, blosc (with shuffle/bitshuffle), gzip, and crc32c checksums, with prebuilt binaries for Linux, Windows, and Apple Silicon bundled in the [File Exchange](https://www.mathworks.com/matlabcentral/fileexchange/184186-zarr-matlab-zarr-v3-for-matlab) installer
+- **Sharding**: thousands of small chunks stored inside each cloud object, read individually via byte-range requests
+- **Cloud-friendly stores**: local directories, zip archives, in-memory, and read-only HTTP(S) — plus consolidated metadata, so opening a big hierarchy costs one request instead of hundreds
+- **MATLAB-native ergonomics**: ordinary 1-based indexing with `end` and logical masks, `disp`/`tree` displays, a `.mltbx` you can double-click
+
+## Interoperability is the contract
+
+The reason to store data in Zarr is that your collaborators, and your future self, can read it from any language. So zarr-matlab treats compatibility with [zarr-python](https://zarr.readthedocs.io/) as its design contract: on every commit, CI has zarr-python write a 43-case matrix covering every data type × codec × sharding layout, verifies MATLAB reads every byte correctly, then verifies zarr-python can read everything MATLAB writes. Documentation is also executed by the test suite.
+
+## Where this is going
+
+zarr-matlab is a foundation as much as a product. Two projects are already building on it:
+
+- **[hdmf-zarr-matlab](https://github.com/catalystneuro/hdmf-zarr-matlab)** implements the [hdmf-zarr](https://github.com/hdmf-dev/hdmf-zarr) conventions for links and object references — the path to reading and writing **NWB files stored as Zarr** from MATLAB.
+- **[matzarr](https://github.com/catalystneuro/matzarr)** attacks a problem every MATLAB lab with cloud data has: reading `.mat` files from object storage without downloading them. A `.mat` v7.3 file is secretly HDF5; matzarr indexes its chunk byte-ranges once into a small virtual-Zarr sidecar, after which MATLAB can open the file's entire structure in one request and stream exactly the slices it needs — cell arrays, structs and all.
+
+If you work with array data in MATLAB — neurophysiology, imaging, climate, anything — give it a try:
+
+- **Install**: [File Exchange](https://www.mathworks.com/matlabcentral/fileexchange/184186-zarr-matlab-zarr-v3-for-matlab) or [GitHub releases](https://github.com/catalystneuro/zarr-matlab/releases)
+- **Docs**: [catalystneuro.github.io/zarr-matlab](https://catalystneuro.github.io/zarr-matlab/)
+- **Issues and interop reports**: [github.com/catalystneuro/zarr-matlab](https://github.com/catalystneuro/zarr-matlab)
+
+*CatalystNeuro builds open-source software for neuroscience data standardization and reuse. If your lab needs help adopting cloud-native data workflows — in Python or MATLAB — [get in touch](https://catalystneuro.com/contact).*


### PR DESCRIPTION
## Summary
- Adds a blog post announcing the zarr-matlab release: a free, open-source, pure-MATLAB implementation of the Zarr v3 spec
- Covers the feature set (compression, sharding, cloud stores), the zarr-python interoperability testing contract, and the hdmf-zarr-matlab / matzarr projects building on it
- Adds a custom SVG banner image (`images/blog/zarr-matlab-banner.svg`) since no existing project logo was available

## Test plan
- [x] `npm run build` succeeds and generates `dist/blog/introducing-zarr-matlab/index.html`
- [x] Verified title, description, canonical URL, and Open Graph/Twitter meta tags render correctly for the new post
- [ ] Visually review the post and banner image on the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)