### PR TITLE
Use consistent 3:1 aspect ratio for blog banners

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -40,7 +40,7 @@ export const BlogPost = () => {
           alt={post.title}
           loading="lazy"
           decoding="async"
-          className="w-full h-64 object-cover rounded-lg mb-8"
+          className="w-full aspect-[3/1] object-cover rounded-lg mb-8"
         />
         <ReactMarkdown
           rehypePlugins={[rehypeRaw, rehypeSlug]}

--- a/src/components/LatestPosts.tsx
+++ b/src/components/LatestPosts.tsx
@@ -22,7 +22,7 @@ export const LatestPosts = () => {
                     alt={post.title}
                     loading="lazy"
                     decoding="async"
-                    className="w-full h-52 md:h-56 object-cover transition-transform duration-500 group-hover:scale-105"
+                    className="w-full aspect-[3/1] object-cover transition-transform duration-500 group-hover:scale-105"
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                 </div>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -55,7 +55,7 @@ const Blog = () => {
                 alt={post.title}
                 loading="lazy"
                 decoding="async"
-                className="w-full h-48 object-cover rounded-t-lg"
+                className="w-full aspect-[3/1] object-cover rounded-t-lg"
               />
               <CardHeader className="flex-none">
                 <div className="flex items-center justify-between mb-2">


### PR DESCRIPTION
## Summary
- Follow-up to #72. The listing-page card thumbnails (`h-48`) and the post-page header image (`h-64`) used different fixed heights against different container widths, so the same banner image was cropped much more aggressively on the card than on the post itself.
- Both now use `aspect-[3/1]` (matching the banner images' native 1200×400 dimensions) so the visible crop stays proportional regardless of container width.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified generated HTML in `dist/blog/index.html` and `dist/blog/introducing-zarr-matlab/index.html` carries the new `aspect-[3/1]` class
- [ ] Visually review card grid vs. post header on the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)