### PR TITLE
Fix person agreement in Luiz Tauffer's bio

### DIFF
--- a/src/content/team.json
+++ b/src/content/team.json
@@ -16,7 +16,7 @@
       "name": "Luiz Tauffer",
       "isActive": true,
       "role": "Lead Neurodata Scientist",
-      "description": "Luiz has a BSc in Electrical Engineering, MSc in Biomedical Engineering and am currently at the late stages of his PhD in Computational Neuroscience. His research work has been focused on mathematical modelling of biological systems and behaviour, i.e. machine learning and data science applied to the life sciences. He is currently expanding my work to cover for more general machine learning / data science consultancy and software development.",
+      "description": "Luiz has a BSc in Electrical Engineering, MSc in Biomedical Engineering and is currently at the late stages of his PhD in Computational Neuroscience. His research work has been focused on mathematical modelling of biological systems and behaviour, i.e. machine learning and data science applied to the life sciences. He is currently expanding his work to cover more general machine learning / data science consultancy and software development.",
       "image": "/images/team/luiz-tauffer.jpg",
       "github": "https://github.com/luiztauffer",
       "personalPage": "https://luiztauffer.github.io/guacamole-data-science/",


### PR DESCRIPTION
## Summary

Luiz Tauffer's bio in `team.json` mixes third and first person. It reads "Luiz has a BSc... and **am currently** at the late stages of **his** PhD" and later "expanding **my** work", which is grammatically inconsistent and reads as a half-finished conversion from a first-person draft.

This rewrites the two affected clauses fully in the third person, leaving the rest of the bio unchanged:
- "and am currently at the late stages of his PhD" → "and is currently at the late stages of his PhD"
- "He is currently expanding my work to cover for more general" → "He is currently expanding his work to cover more general"

Content only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)