### PR TITLE
Fix misspelling of Alessandra Trapani in NeuroConv author list

### DIFF
--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -16,7 +16,7 @@ interface Publication {
 const publications: Publication[] = [
   {
     title: "NeuroConv: Streamlining Neurophysiology Data Conversion to the NWB Standard",
-    authors: "Mayorquin H, Baker C, Adkisson-Floro P, Weigl S, Trappani A, Tauffer L, Rübel O, Dichter B",
+    authors: "Mayorquin H, Baker C, Adkisson-Floro P, Weigl S, Trapani A, Tauffer L, Rübel O, Dichter B",
     journal: "SciPy Proceedings",
     year: 2025,
     doi: "10.25080/cehj4257",


### PR DESCRIPTION
## Summary

The NeuroConv publication on the Publications page listed the author as "Trappani A" (doubled p). The correct spelling is **Trapani A**, matching Alessandra Trapani's entry in `team.json` and the team page.

One-character fix, content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)