### PR TITLE
Align partner-institutions stat with the institutions banner

### DIFF
--- a/src/components/WhyUs.tsx
+++ b/src/components/WhyUs.tsx
@@ -3,7 +3,7 @@ import { Users, FolderGit2, Building2 } from "lucide-react";
 const stats = [
   { label: "Research Labs", value: "60+", icon: Users },
   { label: "Funded Projects", value: "14", icon: FolderGit2 },
-  { label: "Partner Institutions", value: "25+", icon: Building2 },
+  { label: "Partner Institutions", value: "30+", icon: Building2 },
 ];
 
 export const WhyUs = () => {


### PR DESCRIPTION
## Summary

The homepage contradicts itself on the number of partner institutions:

- The **Why Us** stat block says "**25+** Partner Institutions" (`WhyUs.tsx`).
- The **Institutions** banner says "Working with Labs at **30+** Institutions" and lists 30 logos (`InstitutionsBanner.tsx`).

This bumps the Why Us stat to **30+** so both agree. I used 30+ rather than 25+ because there are 30 institution logos actually shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)