### PR TITLE
Normalize species labels on two conversions

### DIFF
--- a/src/content/nwb-conversions/janelia-ahrens-lab.md
+++ b/src/content/nwb-conversions/janelia-ahrens-lab.md
@@ -7,5 +7,5 @@ github: "https://github.com/catalystneuro/ahrens-lab-to-nwb"
 dandi: "https://dandiarchive.org/dandiset/000350"
 date: "2022-07"
 funded_project: "SCGB NWB Adoption"
-species: Zebra fish
+species: Zebrafish
 ---

--- a/src/content/nwb-conversions/stanford-clandinin-lab.md
+++ b/src/content/nwb-conversions/stanford-clandinin-lab.md
@@ -7,5 +7,5 @@ github: "https://github.com/catalystneuro/clandinin-lab-to-nwb"
 dandi: "https://dandiarchive.org/dandiset/000727"
 date: "2023-07"
 funded_project: "SCPAB NWB Adoption"
-species: Fruit fly
+species: Drosophila
 ---


### PR DESCRIPTION
## Summary

Two conversion entries used species labels that split the same animal into separate filter options on the NWB Conversions page:

- **Clandinin lab** was tagged `Fruit fly`, while the seven other fly labs use `Drosophila`. Changed to `Drosophila`.
- **Ahrens lab** used `Zebra fish` (two words). Changed to the conventional single-word `Zebrafish`.

After this, the species filter lists each species once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)