### PR TITLE
Add product and design system records, and fix tertiary text contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# impeccable live-mode session journals (local recovery state, not project source)
+.impeccable/live/sessions/

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,239 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-28T00:00:00Z",
+  "title": "Design System: CatalystNeuro",
+  "extensions": {
+    "colorMeta": {
+      "ink": {
+        "role": "neutral",
+        "displayName": "Rig Ink",
+        "canonical": "#0a0e28",
+        "tonalRamp": ["oklch(15% 0.07 275)", "oklch(26% 0.07 275)", "oklch(37% 0.07 275)", "oklch(48% 0.07 275)", "oklch(59% 0.07 275)", "oklch(70% 0.07 275)", "oklch(81% 0.07 275)", "oklch(92% 0.07 275)"]
+      },
+      "navy": {
+        "role": "neutral",
+        "displayName": "Brand Navy",
+        "canonical": "#101642",
+        "tonalRamp": ["oklch(15% 0.09 275)", "oklch(26% 0.09 275)", "oklch(37% 0.09 275)", "oklch(48% 0.09 275)", "oklch(59% 0.09 275)", "oklch(70% 0.09 275)", "oklch(81% 0.09 275)", "oklch(92% 0.09 275)"]
+      },
+      "blue": {
+        "role": "primary",
+        "displayName": "Signal Blue",
+        "canonical": "#1466a7",
+        "tonalRamp": ["oklch(15% 0.11 245)", "oklch(26% 0.11 245)", "oklch(37% 0.11 245)", "oklch(48% 0.11 245)", "oklch(59% 0.11 245)", "oklch(70% 0.11 245)", "oklch(81% 0.11 245)", "oklch(92% 0.11 245)"]
+      },
+      "blue-600": {
+        "role": "primary",
+        "displayName": "Deep Blue",
+        "canonical": "#0f5289",
+        "tonalRamp": ["oklch(15% 0.10 247)", "oklch(26% 0.10 247)", "oklch(37% 0.10 247)", "oklch(48% 0.10 247)", "oklch(59% 0.10 247)", "oklch(70% 0.10 247)", "oklch(81% 0.10 247)", "oklch(92% 0.10 247)"]
+      },
+      "blue-50": {
+        "role": "primary",
+        "displayName": "Wash Blue",
+        "canonical": "#eef6fc",
+        "tonalRamp": ["oklch(15% 0.02 240)", "oklch(26% 0.02 240)", "oklch(37% 0.02 240)", "oklch(48% 0.02 240)", "oklch(59% 0.02 240)", "oklch(70% 0.02 240)", "oklch(81% 0.02 240)", "oklch(97% 0.02 240)"]
+      },
+      "signal": {
+        "role": "secondary",
+        "displayName": "Live Cyan",
+        "canonical": "#22c7e6",
+        "tonalRamp": ["oklch(15% 0.13 210)", "oklch(26% 0.13 210)", "oklch(37% 0.13 210)", "oklch(48% 0.13 210)", "oklch(59% 0.13 210)", "oklch(70% 0.13 210)", "oklch(81% 0.13 210)", "oklch(92% 0.13 210)"]
+      },
+      "signal-soft": {
+        "role": "secondary",
+        "displayName": "Cyan Soft",
+        "canonical": "#7fe0f0",
+        "tonalRamp": ["oklch(15% 0.09 205)", "oklch(26% 0.09 205)", "oklch(37% 0.09 205)", "oklch(48% 0.09 205)", "oklch(59% 0.09 205)", "oklch(70% 0.09 205)", "oklch(81% 0.09 205)", "oklch(92% 0.09 205)"]
+      },
+      "paper": {
+        "role": "neutral",
+        "displayName": "Cool Paper",
+        "canonical": "#f5f8fc",
+        "tonalRamp": ["oklch(15% 0.006 250)", "oklch(26% 0.006 250)", "oklch(37% 0.006 250)", "oklch(48% 0.006 250)", "oklch(59% 0.006 250)", "oklch(70% 0.006 250)", "oklch(81% 0.006 250)", "oklch(97% 0.006 250)"]
+      },
+      "line": {
+        "role": "neutral",
+        "displayName": "Hairline",
+        "canonical": "#dfe6f1",
+        "tonalRamp": ["oklch(15% 0.014 250)", "oklch(26% 0.014 250)", "oklch(37% 0.014 250)", "oklch(48% 0.014 250)", "oklch(59% 0.014 250)", "oklch(70% 0.014 250)", "oklch(81% 0.014 250)", "oklch(92% 0.014 250)"]
+      },
+      "ink-muted": {
+        "role": "neutral",
+        "displayName": "Muted Ink",
+        "canonical": "#55607a",
+        "tonalRamp": ["oklch(15% 0.035 265)", "oklch(26% 0.035 265)", "oklch(37% 0.035 265)", "oklch(48% 0.035 265)", "oklch(59% 0.035 265)", "oklch(70% 0.035 265)", "oklch(81% 0.035 265)", "oklch(92% 0.035 265)"]
+      },
+      "facet-species": {
+        "role": "tertiary",
+        "displayName": "Species Amber",
+        "canonical": "#b45309",
+        "tonalRamp": ["oklch(15% 0.13 60)", "oklch(26% 0.13 60)", "oklch(37% 0.13 60)", "oklch(48% 0.13 60)", "oklch(59% 0.13 60)", "oklch(70% 0.13 60)", "oklch(81% 0.13 60)", "oklch(92% 0.13 60)"]
+      },
+      "facet-area": {
+        "role": "tertiary",
+        "displayName": "Area Green",
+        "canonical": "#15803d",
+        "tonalRamp": ["oklch(15% 0.12 150)", "oklch(26% 0.12 150)", "oklch(37% 0.12 150)", "oklch(48% 0.12 150)", "oklch(59% 0.12 150)", "oklch(70% 0.12 150)", "oklch(81% 0.12 150)", "oklch(92% 0.12 150)"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Hero headline only, capped at a 16ch measure. Second line takes Live Cyan." },
+      "headline": { "displayName": "Headline", "purpose": "The h1 on every interior page, always preceded by a mono eyebrow." },
+      "title": { "displayName": "Section Title", "purpose": "Section headings, capped at a 20ch measure to force short declarative phrases." },
+      "body": { "displayName": "Body", "purpose": "Interface copy: cards, navigation, forms." },
+      "prose": { "displayName": "Prose", "purpose": "Long-form articles and guides, set in Prose Ink at a 1.75 leading." },
+      "label": { "displayName": "Eyebrow", "purpose": "The recurring mono eyebrow with a 1.6rem leading hairline dash. Opens every section." },
+      "data": { "displayName": "Data", "purpose": "Machine-produced values: tags, badges, stamps, counts, pagination, table headers." }
+    },
+    "shadows": [
+      { "name": "button-rest", "value": "0 1px 2px rgba(16,22,66,0.16)", "purpose": "The only resting shadow in the system, seating a primary button on the page." },
+      { "name": "button-hover", "value": "0 8px 24px -8px rgba(20,102,167,0.55)", "purpose": "Colored glow in the blue's own hue, paired with a 1px lift." },
+      { "name": "card-hover", "value": "0 20px 40px -28px rgba(16,22,66,0.4)", "purpose": "Long soft lift on card hover, paired with a 3px translate and a border shift toward Signal Blue." },
+      { "name": "menu-float", "value": "0 18px 40px -20px rgba(16,22,66,0.35)", "purpose": "Navigation dropdown, the one element that genuinely floats above the page." },
+      { "name": "code-block", "value": "0 18px 40px -30px rgba(10,14,40,0.9)", "purpose": "Seats a dark code surface inside light prose." },
+      { "name": "focus-halo", "value": "0 0 0 3px var(--color-blue-50)", "purpose": "Input and search focus halo, paired with a border shift to Signal Blue." },
+      { "name": "live-glow", "value": "drop-shadow(0 0 6px rgba(34,199,230,0.6))", "purpose": "Applied to the single live trace in the Signal Field. Never used elsewhere." }
+    ],
+    "motion": [
+      { "name": "ease-out-expo", "value": "cubic-bezier(0.16, 1, 0.3, 1)", "purpose": "The system's only easing curve. Buttons, cards, menus, and image scale all use it." },
+      { "name": "duration-instant", "value": "0.15s", "purpose": "Color-only changes: nav links, footer links, inline link hover." },
+      { "name": "duration-control", "value": "0.2s", "purpose": "Button state changes and logo grayscale transitions." },
+      { "name": "duration-surface", "value": "0.25s", "purpose": "Card hover: border, shadow, and transform together." },
+      { "name": "duration-image", "value": "0.4s", "purpose": "Post card image scale to 1.04 on hover." },
+      { "name": "sweep", "value": "6s linear infinite", "purpose": "The Signal Field's live trace stroke-dashoffset sweep. Disabled under prefers-reduced-motion." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "cards-2up", "value": "700px" },
+      { "name": "md", "value": "780px" },
+      { "name": "lg", "value": "860px" },
+      { "name": "nav", "value": "960px" },
+      { "name": "cards-3up", "value": "1050px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The single call to action on a light surface. Carries the only resting shadow in the system.",
+      "html": "<button class=\"ds-btn ds-btn-primary\">Request consultation <svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M5 12h14M12 5l7 7-7 7\"/></svg></button>",
+      "css": ".ds-btn { display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; font-family: var(--font-sans, 'Inter Variable', Inter, system-ui, sans-serif); font-weight: 500; font-size: 0.95rem; padding: 0.7rem 1.35rem; border-radius: 0.55rem; border: 1px solid transparent; white-space: nowrap; cursor: pointer; transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-primary { background: var(--color-blue, #1466a7); color: #fff; box-shadow: 0 1px 2px rgba(16,22,66,0.16); } .ds-btn-primary:hover { background: var(--color-blue-600, #0f5289); transform: translateY(-1px); box-shadow: 0 8px 24px -8px rgba(20,102,167,0.55); } .ds-btn-primary:focus-visible { outline: 2px solid var(--color-blue, #1466a7); outline-offset: 3px; border-radius: 2px; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Secondary action on light surfaces. Hairline border, no fill, no lift.",
+      "html": "<button class=\"ds-btn ds-btn-ghost\">View all posts</button>",
+      "css": ".ds-btn { display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; font-family: var(--font-sans, 'Inter Variable', Inter, system-ui, sans-serif); font-weight: 500; font-size: 0.95rem; padding: 0.7rem 1.35rem; border-radius: 0.55rem; border: 1px solid transparent; white-space: nowrap; cursor: pointer; transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-ghost { background: transparent; color: var(--color-navy, #101642); border-color: var(--color-line, #dfe6f1); } .ds-btn-ghost:hover { border-color: var(--color-blue, #1466a7); color: var(--color-blue, #1466a7); } .ds-btn-ghost:focus-visible { outline: 2px solid var(--color-blue, #1466a7); outline-offset: 3px; }"
+    },
+    {
+      "name": "On-Dark Button",
+      "kind": "button",
+      "refersTo": "button-ondark",
+      "description": "The only correct secondary button on ink or navy surfaces. Inverts to solid white on hover.",
+      "html": "<div class=\"ds-ondark-stage\"><button class=\"ds-btn ds-btn-ondark\">See conversion work</button></div>",
+      "css": ".ds-ondark-stage { background: var(--color-ink, #0a0e28); padding: 1.75rem; border-radius: 0.9rem; } .ds-btn { display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; font-family: var(--font-sans, 'Inter Variable', Inter, system-ui, sans-serif); font-weight: 500; font-size: 0.95rem; padding: 0.7rem 1.35rem; border-radius: 0.55rem; border: 1px solid transparent; white-space: nowrap; cursor: pointer; transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-ondark { background: rgba(255,255,255,0.08); color: #fff; border-color: rgba(255,255,255,0.22); } .ds-btn-ondark:hover { background: #fff; color: var(--color-navy, #101642); } .ds-btn-ondark:focus-visible { outline: 2px solid var(--color-signal, #22c7e6); outline-offset: 3px; }"
+    },
+    {
+      "name": "Eyebrow",
+      "kind": "custom",
+      "refersTo": "eyebrow",
+      "description": "The structural drumbeat of the system: a wide-tracked mono label with a 1.6rem leading hairline dash. Opens every section and interior page header.",
+      "html": "<span class=\"ds-eyebrow\">Portfolio</span>",
+      "css": ".ds-eyebrow { font-family: var(--font-mono, 'JetBrains Mono Variable', ui-monospace, monospace); font-size: 0.72rem; font-weight: 500; letter-spacing: 0.22em; text-transform: uppercase; color: var(--color-blue, #1466a7); display: inline-flex; align-items: center; gap: 0.6rem; } .ds-eyebrow::before { content: ''; width: 1.6rem; height: 1px; background: currentColor; opacity: 0.55; }"
+    },
+    {
+      "name": "Portfolio Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Flat at rest on a hairline border. Hover adds a long soft shadow, a 3px lift, and a border blended 45 percent toward Signal Blue.",
+      "html": "<article class=\"ds-card ds-card-hover\"><div class=\"ds-card-head\"><div><h3>Gyorgy Buzsaki</h3><div class=\"ds-card-sub\">New York University</div></div><span class=\"ds-stamp\">2024-03</span></div><p class=\"ds-card-desc\">Conversion of large-scale hippocampal recordings to NWB, published to the DANDI Archive with a reproducible pipeline.</p><div class=\"ds-card-tags\"><span class=\"ds-tag ds-tag-species\">Rat</span><span class=\"ds-tag ds-tag-method\">electrophysiology</span><span class=\"ds-tag ds-tag-area\">spatial navigation</span></div></article>",
+      "css": ".ds-card { background: var(--color-surface, #ffffff); border: 1px solid var(--color-line, #dfe6f1); border-radius: 0.9rem; padding: 1.5rem; max-width: 22rem; font-family: var(--font-sans, 'Inter Variable', Inter, system-ui, sans-serif); transition: border-color 0.25s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.25s cubic-bezier(0.16, 1, 0.3, 1), transform 0.25s cubic-bezier(0.16, 1, 0.3, 1); } .ds-card-hover:hover { border-color: color-mix(in srgb, var(--color-blue, #1466a7) 45%, var(--color-line, #dfe6f1)); box-shadow: 0 20px 40px -28px rgba(16,22,66,0.4); transform: translateY(-3px); } .ds-card-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 0.8rem; } .ds-card h3 { font-family: var(--font-display, 'Figtree Variable', Figtree, system-ui, sans-serif); font-size: 1.12rem; font-weight: 600; line-height: 1.2; letter-spacing: -0.02em; color: var(--color-navy, #101642); margin: 0; } .ds-card-sub { color: var(--color-blue, #1466a7); font-size: 0.82rem; margin-top: 0.25rem; } .ds-stamp { font-family: var(--font-mono, 'JetBrains Mono Variable', ui-monospace, monospace); font-size: 0.7rem; color: var(--color-ink-soft, #68718b); border: 1px solid var(--color-line, #dfe6f1); border-radius: 0.3rem; padding: 0.15rem 0.4rem; flex-shrink: 0; } .ds-card-desc { color: var(--color-ink-muted, #55607a); font-size: 0.88rem; line-height: 1.55; margin: 0.9rem 0 0; } .ds-card-tags { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-top: 0.9rem; } .ds-tag { font-family: var(--font-mono, 'JetBrains Mono Variable', ui-monospace, monospace); font-size: 0.68rem; letter-spacing: 0.04em; padding: 0.2rem 0.55rem; border-radius: 0.35rem; white-space: nowrap; background: #eef1f6; color: #4b5675; } .ds-tag-species { background: color-mix(in srgb, #f59e0b 15%, white); color: #b45309; } .ds-tag-method { background: var(--color-blue-50, #eef6fc); color: var(--color-blue-600, #0f5289); } .ds-tag-area { background: color-mix(in srgb, #16a34a 12%, white); color: #15803d; }"
+    },
+    {
+      "name": "Search Field",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "A hairline shell containing a Soft Ink magnifier and a borderless input. Focus is applied to the wrapper so the icon and field read as one control.",
+      "html": "<div class=\"ds-search\"><svg width=\"17\" height=\"17\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><circle cx=\"11\" cy=\"11\" r=\"7\"/><path d=\"m20 20-3.5-3.5\"/></svg><input type=\"search\" placeholder=\"Search by lab, institution, or description…\" aria-label=\"Search conversions\" /></div>",
+      "css": ".ds-search { display: flex; align-items: center; gap: 0.5rem; width: 22rem; max-width: 100%; padding: 0.6rem 0.9rem; border: 1px solid var(--color-line, #dfe6f1); border-radius: 0.55rem; background: var(--color-surface, #ffffff); color: var(--color-ink-soft, #68718b); transition: border-color 0.15s, box-shadow 0.15s; } .ds-search:focus-within { border-color: var(--color-blue, #1466a7); box-shadow: 0 0 0 3px var(--color-blue-50, #eef6fc); } .ds-search input { border: 0; outline: 0; flex: 1; min-width: 0; background: transparent; font-family: var(--font-sans, 'Inter Variable', Inter, system-ui, sans-serif); font-size: 0.92rem; color: var(--color-navy, #101642); } .ds-search input::placeholder { color: var(--color-ink-soft, #68718b); }"
+    },
+    {
+      "name": "Filter Select",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Dropdown filter. When a value is applied it takes the set state, filling Wash Blue with a Signal Blue border, so active filters are visible without a separate chip row.",
+      "html": "<div class=\"ds-select-row\"><select class=\"ds-select\" aria-label=\"Method\"><option>All methods</option></select><select class=\"ds-select ds-select-set\" aria-label=\"Species\"><option>Rat</option></select></div>",
+      "css": ".ds-select-row { display: flex; gap: 0.7rem; flex-wrap: wrap; } .ds-select { padding: 0.55rem 0.8rem; border: 1px solid var(--color-line, #dfe6f1); border-radius: 0.55rem; background: var(--color-surface, #ffffff); font-family: var(--font-sans, 'Inter Variable', Inter, system-ui, sans-serif); font-size: 0.85rem; color: var(--color-navy, #101642); cursor: pointer; max-width: 12rem; } .ds-select:hover { border-color: var(--color-blue, #1466a7); } .ds-select:focus-visible { outline: 2px solid var(--color-blue, #1466a7); outline-offset: 3px; } .ds-select-set { border-color: var(--color-blue, #1466a7); background: var(--color-blue-50, #eef6fc); color: var(--color-blue-600, #0f5289); font-weight: 500; }"
+    },
+    {
+      "name": "Status Badge",
+      "kind": "chip",
+      "refersTo": "badge-green",
+      "description": "Funded-project status. Green is active, gray is completed, amber is pending, blue is anything else. The mapping is a legend and must not be reassigned.",
+      "html": "<div class=\"ds-badge-row\"><span class=\"ds-badge ds-badge-green\">active</span><span class=\"ds-badge ds-badge-gray\">completed</span><span class=\"ds-badge ds-badge-amber\">pending</span><span class=\"ds-badge ds-badge-blue\">renewal</span></div>",
+      "css": ".ds-badge-row { display: flex; gap: 0.4rem; flex-wrap: wrap; } .ds-badge { font-family: var(--font-mono, 'JetBrains Mono Variable', ui-monospace, monospace); font-size: 0.68rem; letter-spacing: 0.04em; text-transform: capitalize; padding: 0.22rem 0.6rem; border-radius: 0.35rem; font-weight: 500; white-space: nowrap; } .ds-badge-green { background: color-mix(in srgb, #16a34a 12%, white); color: #15803d; } .ds-badge-gray { background: #eef1f6; color: #4b5675; } .ds-badge-amber { background: color-mix(in srgb, #f59e0b 16%, white); color: #b45309; } .ds-badge-blue { background: var(--color-blue-50, #eef6fc); color: var(--color-blue-600, #0f5289); }"
+    },
+    {
+      "name": "Navigation",
+      "kind": "nav",
+      "refersTo": "nav-link",
+      "description": "Sticky bar at a fixed 4.25rem height with an 82 percent paper fill and a 12px backdrop blur. Hover fills Wash Blue; the active route is Signal Blue text with no fill.",
+      "html": "<nav class=\"ds-nav\" aria-label=\"Primary\"><a class=\"ds-nav-link ds-nav-active\" href=\"#\">Portfolio</a><a class=\"ds-nav-link\" href=\"#\">Software</a><a class=\"ds-nav-link\" href=\"#\">Blog</a><a class=\"ds-nav-link\" href=\"#\">Contact</a></nav>",
+      "css": ".ds-nav { display: flex; align-items: center; gap: 0.25rem; height: 4.25rem; padding: 0 1rem; background: color-mix(in srgb, var(--color-paper, #f5f8fc) 82%, transparent); backdrop-filter: blur(12px); border-bottom: 1px solid var(--color-line, #dfe6f1); } .ds-nav-link { font-family: var(--font-sans, 'Inter Variable', Inter, system-ui, sans-serif); font-size: 1.08rem; font-weight: 500; color: var(--color-navy, #101642); text-decoration: none; padding: 0.5rem 0.8rem; border-radius: 0.45rem; transition: color 0.15s, background 0.15s; } .ds-nav-link:hover { color: var(--color-blue, #1466a7); background: var(--color-blue-50, #eef6fc); } .ds-nav-active { color: var(--color-blue, #1466a7); } .ds-nav-link:focus-visible { outline: 2px solid var(--color-blue, #1466a7); outline-offset: 3px; }"
+    },
+    {
+      "name": "Signal Field",
+      "kind": "custom",
+      "refersTo": "signal-field",
+      "description": "The signature component. Electrophysiology channels drawn as SVG traces on a dark surface, with exactly one live channel in Live Cyan carrying a 6 second sweep. Decorative and aria-hidden.",
+      "html": "<div class=\"ds-signal\" aria-hidden=\"true\"><svg viewBox=\"0 0 360 138\" preserveAspectRatio=\"none\" width=\"100%\" height=\"100%\"><defs><linearGradient id=\"ds-sig-fade\" x1=\"0\" x2=\"1\"><stop offset=\"0\" stop-color=\"var(--color-signal, #22c7e6)\" stop-opacity=\"0\"></stop><stop offset=\"0.5\" stop-color=\"var(--color-signal, #22c7e6)\" stop-opacity=\"1\"></stop><stop offset=\"1\" stop-color=\"var(--color-signal, #22c7e6)\" stop-opacity=\"0\"></stop></linearGradient></defs><line x1=\"0\" x2=\"360\" y1=\"23\" y2=\"23\" stroke=\"rgba(255,255,255,0.06)\"></line><line x1=\"0\" x2=\"360\" y1=\"69\" y2=\"69\" stroke=\"rgba(255,255,255,0.06)\"></line><line x1=\"0\" x2=\"360\" y1=\"115\" y2=\"115\" stroke=\"rgba(255,255,255,0.06)\"></line><path d=\"M0,23 L24,22 L48,24 L60,13 L72,23 L108,24 L132,22 L144,31 L168,23 L204,22 L228,24 L240,12 L264,23 L300,24 L324,22 L360,23\" fill=\"none\" stroke=\"rgba(127,224,240,0.28)\" stroke-width=\"1.25\"></path><path class=\"ds-trace-live\" d=\"M0,69 L36,68 L60,70 L72,57 L84,69 L120,70 L144,68 L156,78 L180,69 L216,68 L240,70 L252,56 L276,69 L312,70 L336,68 L360,69\" fill=\"none\" stroke=\"url(#ds-sig-fade)\" stroke-width=\"2\"></path><path d=\"M0,115 L24,114 L48,116 L72,115 L84,105 L96,115 L132,116 L156,114 L168,123 L192,115 L228,114 L252,116 L288,115 L300,104 L312,115 L360,115\" fill=\"none\" stroke=\"rgba(127,224,240,0.28)\" stroke-width=\"1.25\"></path></svg></div>",
+      "css": ".ds-signal { width: 100%; height: 138px; background: radial-gradient(120% 120% at 80% -10%, #1b2358 0%, var(--color-ink, #0a0e28) 55%); border-radius: 0.9rem; overflow: hidden; } .ds-trace-live { filter: drop-shadow(0 0 6px rgba(34,199,230,0.6)); stroke-dasharray: 70 310; animation: ds-sweep 6s linear infinite; } @keyframes ds-sweep { to { stroke-dashoffset: -380; } } @media (prefers-reduced-motion: reduce) { .ds-trace-live { animation: none; stroke-dasharray: none; } }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Live Recording",
+    "overview": "The site is built to look like a multichannel neural recording in progress, because that is what its clients spend their lives looking at. The hero is an acquisition surface: near black, with nine electrophysiology traces drawn as real SVG paths behind the headline, one of them highlighted in electric cyan and carrying a slow sweeping pulse. Every other surface in the system inherits that logic. Structure is drawn with hairlines the way a rig draws channel rules. Anything a machine produced (a date, a count, a dandiset id, a species tag, a page number) is set in monospace, the way a readout would print it. Anything a person wrote is set in a humanist sans, because it came from a person.\n\nThe result is deliberately not a SaaS marketing site, and the previous generic-SaaS visual language is the explicit anti-reference. There are no gradient mesh blobs, no floating 3D product mockups, no stock photographs of scientists pointing at monitors, and no illustration standing in for data. The subject matter supplies the imagery. When a page needs a visual, the honest answer is nearly always a real artifact: a trace, a logo grid, a photograph the team actually took, or a hairline table of facts.\n\nRestraint is what makes the one moment of energy land. The palette is overwhelmingly navy, paper, and hairline gray; the cyan appears roughly once per viewport and always on something that is genuinely live or active. Surfaces are flat at rest and earn their shadow only through interaction. The density is technical without being cramped: a 76rem measure, 5rem section rhythm, and long comfortable line lengths in prose, so a principal investigator can read a 3000-word technical post without fatigue and a program officer can scan 62 conversion cards without losing their place.",
+    "keyCharacteristics": [
+      "Dark acquisition surfaces frame the page; the interior is always paper or white.",
+      "Structure is drawn with 1px hairlines, never with resting shadow.",
+      "Monospace is a semantic signal, not a texture: it means a machine produced this fact.",
+      "One electric cyan accent, used roughly once per viewport, reserved for the live thing.",
+      "Real signal geometry instead of decorative abstraction or stock imagery.",
+      "Motion is slow, linear, and rare: a 6-second trace sweep, a 1px lift on hover."
+    ],
+    "rules": [
+      { "name": "The One Live Channel Rule", "body": "Live Cyan appears about once per viewport, and only on something that is genuinely live, active, or selected. If a second cyan element enters the same screen, one of them is decoration and should be Signal Blue or a neutral instead. The hero works because eight traces are quiet and one is not.", "section": "colors" },
+      { "name": "The Borrowed Navy Rule", "body": "Navy is simultaneously the heading color, the body color, and a surface fill. Never introduce a second dark neutral to separate text from surface; use the existing navy family (navy-700, navy-600) or opacity on white.", "section": "colors" },
+      { "name": "The Facet Color Rule", "body": "Amber means species, green means research area, blue means method. These three are a legend, not a palette. Do not reassign them, and do not use them for emphasis anywhere outside taxonomy chips and status badges.", "section": "colors" },
+      { "name": "The Machine Fact Rule", "body": "JetBrains Mono is reserved for values a machine produced or a system indexes: dates, counts, identifiers, tags, statuses, code, page numbers, and structural eyebrows. It never sets a sentence a human wrote. If you are tempted to set a human phrase in mono for texture, the answer is small-caps-weight Inter instead.", "section": "typography" },
+      { "name": "The Twenty Character Rule", "body": "Section titles are capped at a 20ch measure and hero titles at 16ch. If a title does not fit, shorten the title rather than raising the cap.", "section": "typography" },
+      { "name": "The Eyebrow Precedes Rule", "body": "Every major section and every interior page header opens with a mono eyebrow above the heading. It is the system's structural drumbeat, and skipping it makes a page read as though it belongs to a different site.", "section": "typography" },
+      { "name": "The Earned Shadow Rule", "body": "Surfaces are flat until the user does something. If an element has a resting shadow and is not a primary button or a floating menu, remove it and let the hairline do the work.", "section": "elevation" },
+      { "name": "The Long Light Rule", "body": "Every shadow in the system uses a large blur and a large negative spread (-8px to -30px). Short tight shadows read as material and break the instrument character. Match the existing offsets rather than inventing new ones.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do open every section and interior page with a mono eyebrow above the heading, with its 1.6rem leading dash intact.",
+      "Do set machine-produced values (dates, counts, ids, tags, statuses, page numbers) in JetBrains Mono, and human sentences in Inter.",
+      "Do define structure with 1px hairlines. Reach for a border before you reach for a shadow or a fill.",
+      "Do keep Live Cyan to roughly one element per viewport, on something genuinely live, active, or selected. Use Cyan Soft when the accent must carry text on dark.",
+      "Do keep dark surfaces at the frame of a page: the hero opens, a stat band or single band interrupts, the footer closes. Interior content stays on paper or white.",
+      "Do pin card action rows with margin-top: auto so cards in a row end level, and clamp variable-length descriptions rather than letting them set the card height.",
+      "Do honor prefers-reduced-motion; the global rule collapses transitions and the Signal Field drops its sweep entirely.",
+      "Do generate visuals from the subject matter (traces, real logos, real photographs, hairline data tables) when a surface needs interest."
+    ],
+    "donts": [
+      "Don't give a resting element a shadow. Only primary buttons and genuinely floating menus carry shadow at rest; everything else earns it on hover or focus.",
+      "Don't introduce a fourth typeface, or use monospace for a sentence a person wrote.",
+      "Don't reassign the facet colors. Amber is species, green is research area, blue is method, and that legend holds everywhere it appears.",
+      "Don't add gradient blobs, mesh backgrounds, floating 3D mockups, stock photographs of scientists, or illustrations standing in for data. The previous generic-SaaS look is the anti-reference, not a fallback.",
+      "Don't stack dark sections through the middle of a page, and don't put a dark band directly against the footer.",
+      "Don't exceed 0.9rem radius on any surface, or use pill-shaped buttons.",
+      "Don't widen the container past 76rem or raise the 20ch cap on section titles; shorten the title instead.",
+      "Don't use short tight shadows. Every shadow in this system has a large blur and a large negative spread."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/layouts/Base.astro"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,501 @@
+---
+name: CatalystNeuro
+description: "A neurophysiology recording rendered as a website: dark rig surfaces, hairline structure, monospace readouts, and one live channel."
+colors:
+  ink: "#0a0e28"
+  navy: "#101642"
+  navy-700: "#1b2358"
+  navy-600: "#283066"
+  blue: "#1466a7"
+  blue-600: "#0f5289"
+  blue-400: "#3f8cca"
+  blue-100: "#dceaf6"
+  blue-50: "#eef6fc"
+  signal: "#22c7e6"
+  signal-soft: "#7fe0f0"
+  paper: "#f5f8fc"
+  surface: "#ffffff"
+  line: "#dfe6f1"
+  line-soft: "#ecf1f8"
+  ink-muted: "#55607a"
+  ink-soft: "#68718b"
+  prose-body: "#313a54"
+  facet-species: "#b45309"
+  facet-area: "#15803d"
+typography:
+  display:
+    fontFamily: "Figtree Variable, Figtree, system-ui, sans-serif"
+    fontSize: "clamp(2.5rem, 6.5vw, 4.6rem)"
+    fontWeight: 600
+    lineHeight: 1.02
+    letterSpacing: "-0.02em"
+  headline:
+    fontFamily: "Figtree Variable, Figtree, system-ui, sans-serif"
+    fontSize: "clamp(2.1rem, 5vw, 3.1rem)"
+    fontWeight: 600
+    lineHeight: 1.08
+    letterSpacing: "-0.02em"
+  title:
+    fontFamily: "Figtree Variable, Figtree, system-ui, sans-serif"
+    fontSize: "clamp(1.8rem, 3.5vw, 2.4rem)"
+    fontWeight: 600
+    lineHeight: 1.08
+    letterSpacing: "-0.02em"
+  body:
+    fontFamily: "Inter Variable, Inter, system-ui, -apple-system, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "normal"
+  prose:
+    fontFamily: "Inter Variable, Inter, system-ui, -apple-system, sans-serif"
+    fontSize: "1.075rem"
+    fontWeight: 400
+    lineHeight: 1.75
+    letterSpacing: "normal"
+  label:
+    fontFamily: "JetBrains Mono Variable, JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.72rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "0.22em"
+  data:
+    fontFamily: "JetBrains Mono Variable, JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.68rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "0.04em"
+rounded:
+  xs: "0.3rem"
+  sm: "0.35rem"
+  base: "0.45rem"
+  md: "0.55rem"
+  lg: "0.7rem"
+  xl: "0.9rem"
+spacing:
+  hairline: "1px"
+  xs: "0.35rem"
+  sm: "0.6rem"
+  md: "1.2rem"
+  lg: "1.8rem"
+  section: "5rem"
+  container: "76rem"
+  gutter: "1.5rem"
+components:
+  button-primary:
+    backgroundColor: "{colors.blue}"
+    textColor: "#ffffff"
+    rounded: "{rounded.md}"
+    padding: "0.7rem 1.35rem"
+    typography: "{typography.body}"
+  button-primary-hover:
+    backgroundColor: "{colors.blue-600}"
+    textColor: "#ffffff"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.navy}"
+    rounded: "{rounded.md}"
+    padding: "0.7rem 1.35rem"
+  button-ghost-hover:
+    textColor: "{colors.blue}"
+  button-ondark:
+    backgroundColor: "rgba(255,255,255,0.08)"
+    textColor: "#ffffff"
+    rounded: "{rounded.md}"
+    padding: "0.7rem 1.35rem"
+  button-ondark-hover:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.navy}"
+  button-sm:
+    padding: "0.45rem 0.85rem"
+  card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.navy}"
+    rounded: "{rounded.xl}"
+    padding: "1.8rem"
+  input:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.navy}"
+    rounded: "{rounded.md}"
+    padding: "0.7rem 0.9rem"
+  eyebrow:
+    textColor: "{colors.blue}"
+    typography: "{typography.label}"
+  tag:
+    backgroundColor: "#eef1f6"
+    textColor: "#4b5675"
+    rounded: "{rounded.sm}"
+    padding: "0.2rem 0.55rem"
+    typography: "{typography.data}"
+  tag-method:
+    backgroundColor: "{colors.blue-50}"
+    textColor: "{colors.blue-600}"
+  badge-green:
+    backgroundColor: "#e7f6ec"
+    textColor: "{colors.facet-area}"
+    rounded: "{rounded.sm}"
+    padding: "0.22rem 0.6rem"
+    typography: "{typography.data}"
+  stamp:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink-soft}"
+    rounded: "{rounded.xs}"
+    padding: "0.15rem 0.4rem"
+    typography: "{typography.data}"
+---
+
+# Design System: CatalystNeuro
+
+## Overview
+
+**Creative North Star: "The Live Recording"**
+
+The site is built to look like a multichannel neural recording in progress, because that
+is what its clients spend their lives looking at. The hero is an acquisition surface: near
+black, with nine electrophysiology traces drawn as real SVG paths behind the headline, one
+of them highlighted in electric cyan and carrying a slow sweeping pulse. Every other
+surface in the system inherits that logic. Structure is drawn with hairlines the way a rig
+draws channel rules. Anything a machine produced (a date, a count, a dandiset id, a
+species tag, a page number) is set in monospace, the way a readout would print it. Anything
+a person wrote is set in a humanist sans, because it came from a person.
+
+The result is deliberately not a SaaS marketing site, and the previous generic-SaaS visual
+language is the explicit anti-reference. There are no gradient mesh blobs, no floating
+3D product mockups, no stock photographs of scientists pointing at monitors, and no
+illustration standing in for data. The subject matter supplies the imagery. When a page
+needs a visual, the honest answer is nearly always a real artifact: a trace, a logo grid,
+a photograph the team actually took, or a hairline table of facts.
+
+Restraint is what makes the one moment of energy land. The palette is overwhelmingly navy,
+paper, and hairline gray; the cyan appears roughly once per viewport and always on
+something that is genuinely live or active. Surfaces are flat at rest and earn their shadow
+only through interaction. The density is technical without being cramped: a 76rem measure,
+5rem section rhythm, and long comfortable line lengths in prose, so a principal
+investigator can read a 3000-word technical post without fatigue and a program officer can
+scan 62 conversion cards without losing their place.
+
+**Key Characteristics:**
+- Dark acquisition surfaces frame the page; the interior is always paper or white.
+- Structure is drawn with 1px hairlines, never with resting shadow.
+- Monospace is a semantic signal, not a texture: it means a machine produced this fact.
+- One electric cyan accent, used roughly once per viewport, reserved for the live thing.
+- Real signal geometry instead of decorative abstraction or stock imagery.
+- Motion is slow, linear, and rare: a 6-second trace sweep, a 1px lift on hover.
+
+## Colors
+
+A cool, instrument-lit palette: two navies deep enough to read as hardware, a single
+working blue inherited from the logo, one electric cyan held in reserve, and a cool paper
+neutral scale that keeps long documents comfortable.
+
+### Primary
+- **Signal Blue** (`{colors.blue}`): the working accent and the logo's own blue. It carries
+  every interactive job on light surfaces: primary buttons, links in prose, eyebrows,
+  active navigation, the focus outline, icon fills, and the selected state of a filter.
+  When something on a paper surface must look clickable, this is the color that says so.
+- **Deep Blue** (`{colors.blue-600}`): the pressed and hovered state of Signal Blue, and
+  the text color inside method tags and inline code where the lighter blue would not hold
+  contrast against a tinted background.
+- **Wash Blue** (`{colors.blue-50}`) and **Mist Blue** (`{colors.blue-100}`): the tinted
+  backgrounds behind method tags, inline code, service icon tiles, navigation hover, and
+  the 3px focus halo on inputs. Mist Blue is used once at scale, as the oversized quotation
+  mark on the testimonial.
+
+### Secondary
+- **Live Cyan** (`{colors.signal}`): the only color in the system not derived from the
+  logo, and the most tightly governed. It marks things that are live, active, or emitting:
+  the highlighted trace in the hero, the pipeline step numbers, the diamond bullets in
+  prose lists, the text selection highlight. On dark surfaces it glows slightly
+  (`drop-shadow(0 0 6px rgba(34,199,230,0.6))` on the live trace only).
+- **Cyan Soft** (`{colors.signal-soft}`): the readable form of the accent for text on ink,
+  used for the hero eyebrow and for link hover in the footer. Use this, not Live Cyan, when
+  the accent has to carry words.
+
+### Tertiary
+The three facet colors exist only to encode a taxonomy on portfolio cards, and are never
+used as brand color. **Species Amber** (`{colors.facet-species}` on a 15% amber wash),
+**Area Green** (`{colors.facet-area}` on a 12% green wash), and Method Blue (Wash Blue with
+Deep Blue text). A reader learns in one card that amber means species and green means
+research area, and that mapping must not be broken for visual variety. Status badges reuse
+the same three washes plus neutral gray for active, pending, completed, and other.
+
+### Neutral
+- **Rig Ink** (`{colors.ink}`): the darkest surface. The hero gradient resolves to it and
+  the footer is a flat field of it. This is the outermost frame of every page.
+- **Brand Navy** (`{colors.navy}`): the logo navy. It is both the default text color for
+  headings and body copy on light surfaces, and the fill of the stats band. Text and
+  surface share one value, which is part of why the system feels coherent.
+- **Navy 700 / 600** (`{colors.navy-700}`, `{colors.navy-600}`): the lit corner of the hero
+  gradient and the border of the code block. Depth inside dark surfaces comes from these,
+  not from shadow.
+- **Cool Paper** (`{colors.paper}`): the page background. Slightly blue and slightly cool,
+  so white cards read as raised without needing a shadow.
+- **Surface White** (`{colors.surface}`): cards, menus, inputs, alternating sections, and
+  the institution grid cells.
+- **Hairline** (`{colors.line}`) and **Hairline Soft** (`{colors.line-soft}`): every border,
+  divider, rule, table cell edge, and the 44px background grid in the page header. These
+  two values do almost all the structural work in the system.
+- **Muted Ink** (`{colors.ink-muted}`) and **Soft Ink** (`{colors.ink-soft}`): secondary
+  and tertiary text. Descriptions, leads, and captions use Muted Ink; timestamps, counts,
+  and disabled affordances use Soft Ink. Both are tuned to clear AA at the small sizes they
+  are used at: Muted Ink measures 6.29:1 on white and 5.90:1 on Cool Paper, Soft Ink 4.86:1
+  and 4.56:1. Soft Ink appears at 0.7rem to 0.8rem on date stamps, post dates, result
+  counts, pagination, and card footers, which is exactly where a lighter gray would fail, so
+  do not lighten it for the sake of hierarchy. If a tertiary value needs to recede further,
+  reduce its size or weight rather than its contrast.
+- **Prose Ink** (`{colors.prose-body}`): long-form body text only. It is marginally warmer
+  and lighter than Brand Navy, tuned for reading a full article rather than scanning a card.
+
+### Named Rules
+
+**The One Live Channel Rule.** Live Cyan appears about once per viewport, and only on
+something that is genuinely live, active, or selected. If a second cyan element enters the
+same screen, one of them is decoration and should be Signal Blue or a neutral instead. The
+hero works because eight traces are quiet and one is not.
+
+**The Borrowed Navy Rule.** Navy is simultaneously the heading color, the body color, and a
+surface fill. Never introduce a second dark neutral to separate text from surface; use the
+existing navy family (`navy-700`, `navy-600`) or opacity on white.
+
+**The Facet Color Rule.** Amber means species, green means research area, blue means
+method. These three are a legend, not a palette. Do not reassign them, and do not use them
+for emphasis anywhere outside taxonomy chips and status badges.
+
+## Typography
+
+**Display Font:** Figtree Variable (with Figtree, system-ui, sans-serif)
+**Body Font:** Inter Variable (with Inter, system-ui, -apple-system, sans-serif)
+**Label/Mono Font:** JetBrains Mono Variable (with JetBrains Mono, ui-monospace, monospace)
+
+**Character:** Figtree is geometric and slightly warm, set at weight 600 with a tight
+`-0.02em` tracking and a 1.02 to 1.08 leading, so headlines read as confident engineering
+rather than as a startup shout. Inter does the reading work without personality of its own,
+which is correct: the sentences are technical and should not fight the reader. JetBrains
+Mono is not decoration, it is the system's semantic marker for machine-produced fact, and
+its wide `0.22em` tracking on eyebrows turns a label into a piece of instrument silkscreen.
+
+### Hierarchy
+- **Display** (600, `clamp(2.5rem, 6.5vw, 4.6rem)`, line-height 1.02): hero headline only.
+  Capped at a 16ch measure so it breaks into short, deliberate lines. The second line takes
+  Live Cyan; the first stays white.
+- **Headline** (600, `clamp(2.1rem, 5vw, 3.1rem)`, line-height 1.08): the `h1` on every
+  interior page, always inside the page header block with an eyebrow above it.
+- **Title** (600, `clamp(1.8rem, 3.5vw, 2.4rem)`, max-width 20ch): section headings. The
+  20ch cap is doing real work; it forces section titles to be short declarative phrases
+  instead of sentences.
+- **Body** (400, 1rem, line-height 1.6): interface copy, cards, navigation, forms.
+- **Prose** (400, 1.075rem, line-height 1.75, Prose Ink): long-form articles and guides.
+  Paragraph rhythm comes from `.prose > * + *` at 1.3em, and `h2` earns a hairline rule
+  above it at 2.4em, so a long post visibly separates into chapters.
+- **Label** (mono, 500, 0.72rem, `0.22em` tracking, uppercase, Signal Blue): the eyebrow.
+  It carries a 1.6rem hairline dash before the text at 55% opacity, which is the single
+  most recognizable device in the system. `.eyebrow--plain` removes the dash when the
+  eyebrow sits inside a card that already has enough structure.
+- **Data** (mono, 0.68rem to 0.8rem, `0.04em` tracking): tags, badges, date stamps, result
+  counts, pagination, table headers, footer column headings, and pipeline step numbers.
+
+### Named Rules
+
+**The Machine Fact Rule.** JetBrains Mono is reserved for values a machine produced or a
+system indexes: dates, counts, identifiers, tags, statuses, code, page numbers, and
+structural eyebrows. It never sets a sentence a human wrote. If you are tempted to set a
+human phrase in mono for texture, the answer is small-caps-weight Inter instead.
+
+**The Twenty Character Rule.** Section titles are capped at a 20ch measure and hero titles
+at 16ch. If a title does not fit, shorten the title rather than raising the cap.
+
+**The Eyebrow Precedes Rule.** Every major section and every interior page header opens
+with a mono eyebrow above the heading. It is the system's structural drumbeat, and skipping
+it makes a page read as though it belongs to a different site.
+
+## Layout
+
+A single centered measure of 76rem with a 1.5rem gutter (`.container-x`) governs every
+page; nothing bleeds full-width except dark bands, the institution grid, and the hero
+background. Vertical rhythm is a 5rem section pad, with alternating sections marked by a
+white fill plus hairline borders on both edges (`.section--alt`) rather than by a change in
+spacing. The page header block sits at 3.5rem top, 2.5rem bottom, closed with a hairline
+and backed by a 44px hairline grid that is masked to a radial fade from the top right, so
+the technical texture is present without becoming a pattern.
+
+Grids resolve at a small number of honest breakpoints rather than a formal scale: 640px
+(institution grid to six columns, footer columns to four), 700px and 1050px (portfolio card
+grid to two then three columns), 780px (three-up feature grids, hero pipeline arrows),
+860px (services, footer split, CTA band), and 960px (the navigation swap from burger to
+full nav). Card grids use a consistent 1.2rem gap. Density is comfortable rather than
+tight: cards carry 1.8rem of internal padding, portfolio cards 1.5rem, and prose runs at
+its natural measure inside the 76rem container.
+
+Two layout devices are worth preserving. The institution grid draws its hairlines by having
+each cell outline itself into a 1px gap, so a partially filled final row shows page
+background rather than a block of border color. The portfolio card is a flex column with
+its link row pinned to the bottom via `margin-top: auto`, so cards in a row end on the same
+line regardless of description length, with descriptions clamped to four lines and expanded
+by an inline control.
+
+## Elevation & Depth
+
+The system is flat at rest and hairline-defined. A card is a white fill with a 1px
+`{colors.line}` border and no shadow. Depth is not used to establish hierarchy; hierarchy
+comes from surface color, hairlines, and type. Shadow enters only as a response to state or
+to genuine floating, and when it does it is long, soft, and heavily negative-spread, so it
+reads as light falling rather than as a drop shadow.
+
+### Shadow Vocabulary
+- **Button rest** (`box-shadow: 0 1px 2px rgba(16,22,66,0.16)`): the single exception to
+  flat-at-rest, just enough to seat a primary button on the page.
+- **Button hover** (`box-shadow: 0 8px 24px -8px rgba(20,102,167,0.55)`): a colored glow in
+  the blue's own hue, paired with a 1px lift.
+- **Card hover** (`box-shadow: 0 20px 40px -28px rgba(16,22,66,0.4)`): paired with a 3px
+  lift and a border that shifts 45% toward Signal Blue.
+- **Floating menu** (`box-shadow: 0 18px 40px -20px rgba(16,22,66,0.35)`): the navigation
+  dropdown, which genuinely floats above the page.
+- **Code block** (`box-shadow: 0 18px 40px -30px rgba(10,14,40,0.9)`): a dark surface inside
+  prose, seated with its own near-black shadow.
+- **Input focus** (`box-shadow: 0 0 0 3px {colors.blue-50}`): a halo, not a shadow, paired
+  with a border shift to Signal Blue.
+
+### Named Rules
+
+**The Earned Shadow Rule.** Surfaces are flat until the user does something. If an element
+has a resting shadow and is not a primary button or a floating menu, remove it and let the
+hairline do the work.
+
+**The Long Light Rule.** Every shadow in the system uses a large blur and a large negative
+spread (`-8px` to `-30px`). Short tight shadows read as material and break the instrument
+character. Match the existing offsets rather than inventing new ones.
+
+## Shapes
+
+Corners are gently rounded on a compact scale that never becomes a pill. The scale runs
+from `{rounded.xs}` on the smallest data chips through `{rounded.md}` on buttons, inputs,
+and filter controls, `{rounded.lg}` on images, code blocks, and icon tiles, up to
+`{rounded.xl}` on cards, which is the largest radius in the system. Nothing is fully round
+except icon-free avatars, and nothing is square except full-bleed dark bands and table
+cells.
+
+Borders are the primary form language: a single 1px `{colors.line}` stroke defines cards,
+inputs, selects, stamps, capability chips, pagination buttons, institution cells, and every
+divider. On dark surfaces the equivalent is `rgba(255,255,255,0.1)` to `0.12`. Focus is a
+2px Signal Blue outline at a 3px offset with a 2px radius, applied globally via
+`:focus-visible`.
+
+The one non-rectilinear form in the system is the prose list bullet: a 6px square rotated
+45 degrees, filled with Live Cyan, sitting at the left of each unordered list item. It is a
+tick mark on a trace, and it is the reason unordered lists in articles feel like part of
+the same world as the hero.
+
+## Components
+
+### Buttons
+- **Shape:** compact rounding (`{rounded.md}`, 0.55rem), 0.7rem by 1.35rem padding, 1px
+  transparent border so all variants share a box model. `.btn-sm` reduces to 0.45rem by
+  0.85rem at 0.82rem type.
+- **Primary:** Signal Blue fill, white text, seated with the button-rest shadow. Hover
+  moves to Deep Blue, lifts 1px, and adds the blue glow over 0.2s on `--ease-out-expo`.
+- **Ghost:** transparent with a hairline border and Brand Navy text; hover shifts both
+  border and text to Signal Blue with no fill and no lift. Used for secondary actions,
+  "view all" links, and pagination edges.
+- **On dark:** 8% white fill with a 22% white border; hover inverts to a solid white fill
+  with navy text. This is the only correct secondary button on ink or navy surfaces.
+- **Focus:** inherits the global 2px Signal Blue outline at 3px offset.
+- Buttons carry a leading or trailing icon at 15 to 16px with a 0.5rem gap. Inline text
+  links inside cards (`.svc-link`) widen their gap from 0.35rem to 0.55rem on hover, which
+  reads as the arrow stepping forward.
+
+### Chips
+- **Taxonomy tags:** mono at 0.68rem, `{rounded.sm}`, 0.2rem by 0.55rem padding, tinted
+  background with a matching darker text color. Three fixed facets: species (amber), method
+  (blue), research area (green). Neutral gray is the untyped default.
+- **Status badges:** the same shape and type, capitalized, with green for active, gray for
+  completed, amber for pending, and blue for anything else.
+- **Stamps:** a mono date or count in Soft Ink inside a hairline border at `{rounded.xs}`.
+  Used at the top right of a portfolio card and beside a page title as a result count.
+- **Capability chips:** larger, 0.55rem by 0.9rem on a paper fill with a hairline border and
+  a leading blue icon. Not interactive.
+
+### Cards / Containers
+- **Corner Style:** `{rounded.xl}` (0.9rem), the largest radius in the system.
+- **Background:** Surface White on Cool Paper; inside a white `.section--alt`, cards still
+  read because of the hairline border.
+- **Shadow Strategy:** none at rest. `.card-hover` adds the card-hover shadow, a 3px lift,
+  and a border blended 45% toward Signal Blue, all on a 0.25s expo ease.
+- **Border:** 1px `{colors.line}`.
+- **Internal Padding:** 1.8rem for feature and service cards, 1.5rem for portfolio cards,
+  1.3rem for post cards where the image already carries the top edge.
+- Post cards clip a 16:9 image at the top and scale it to 1.04 over 0.4s on hover, the only
+  image motion in the system.
+
+### Inputs / Fields
+- **Style:** Surface White fill, 1px hairline border, `{rounded.md}`, 0.7rem by 0.9rem
+  padding, Inter at 0.92rem to 0.95rem.
+- **Focus:** border shifts to Signal Blue and a 3px Wash Blue halo appears. Search fields
+  apply this to the wrapper via `:focus-within` so the icon and input read as one control.
+- **Selects:** the same shell at 0.85rem. A select with a value applied takes `.is-set`,
+  which fills it with Wash Blue, borders it Signal Blue, and sets weight 500, so an active
+  filter is visible without a separate chip row.
+- **Search:** a hairline shell containing a 17px Soft Ink magnifier and a borderless input.
+
+### Navigation
+- Sticky, with an 82% Cool Paper fill and a 12px backdrop blur over a hairline bottom
+  border, at a fixed 4.25rem height that gives the 40px logo mark 14px of clearance.
+- Links are Inter 500 at 1.08rem, navy, on a 0.45rem radius. Hover fills with Wash Blue and
+  colors the text Signal Blue; the active route is Signal Blue text with no fill.
+- Dropdowns open on hover and focus-within, sliding up 4px into place over 0.16s with the
+  floating-menu shadow at `{rounded.lg}`.
+- Below 960px the nav collapses to a burger opening a Surface White panel of flattened
+  links, each separated by a soft hairline, closing on navigation and on any resize back
+  past the breakpoint.
+- A skip link sits above everything, hidden off-canvas at `left: -999px` until focused.
+
+### The Signal Field (signature component)
+
+A stack of electrophysiology channels rendered as real SVG paths, generated at build time
+by a seeded pseudo-random walk so the geometry is stable across builds. Each channel gets a
+baseline noise trace at `rgba(127,224,240,0.28)` over a `rgba(255,255,255,0.06)` channel
+rule, with occasional spikes. One channel (index 2) is the live one: 2px wide, stroked with
+a horizontal gradient that fades to transparent at both edges, glowing at 6px, and animated
+with a `stroke-dasharray` sweep of 6 seconds linear infinite that switches off entirely
+under `prefers-reduced-motion`.
+
+In the hero it sits at 55% opacity behind the content, masked so it fades out from the left
+40% of the viewport and leaves the headline on clean ink. It is decorative and correctly
+marked `aria-hidden`. This component is the system's thesis: when a surface needs visual
+interest, generate it from the subject matter rather than importing it.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** open every section and interior page with a mono eyebrow above the heading, with
+  its 1.6rem leading dash intact.
+- **Do** set machine-produced values (dates, counts, ids, tags, statuses, page numbers) in
+  JetBrains Mono, and human sentences in Inter.
+- **Do** define structure with 1px `{colors.line}` hairlines. Reach for a border before you
+  reach for a shadow or a fill.
+- **Do** keep Live Cyan to roughly one element per viewport, on something genuinely live,
+  active, or selected. Use Cyan Soft when the accent must carry text on dark.
+- **Do** keep dark surfaces at the frame of a page: the hero opens, a stat band or single
+  band interrupts, the footer closes. Interior content stays on paper or white.
+- **Do** pin card action rows with `margin-top: auto` so cards in a row end level, and clamp
+  variable-length descriptions rather than letting them set the card height.
+- **Do** honor `prefers-reduced-motion`; the global rule collapses transitions and the
+  Signal Field drops its sweep entirely.
+- **Do** generate visuals from the subject matter (traces, real logos, real photographs,
+  hairline data tables) when a surface needs interest.
+
+### Don't:
+- **Don't** give a resting element a shadow. Only primary buttons and genuinely floating
+  menus carry shadow at rest; everything else earns it on hover or focus.
+- **Don't** introduce a fourth typeface, or use monospace for a sentence a person wrote.
+- **Don't** reassign the facet colors. Amber is species, green is research area, blue is
+  method, and that legend holds everywhere it appears.
+- **Don't** add gradient blobs, mesh backgrounds, floating 3D mockups, stock photographs of
+  scientists, or illustrations standing in for data. The previous generic-SaaS look is the
+  anti-reference, not a fallback.
+- **Don't** stack dark sections through the middle of a page, and don't put a dark band
+  directly against the footer.
+- **Don't** exceed `{rounded.xl}` (0.9rem) on any surface, or use pill-shaped buttons.
+- **Don't** widen the container past 76rem or raise the 20ch cap on section titles; shorten
+  the title instead.
+- **Don't** use short tight shadows. Every shadow in this system has a large blur and a
+  large negative spread.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,201 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+**Primary: principal investigators running neurophysiology labs.** A PI arrives sitting on
+years of data in proprietary acquisition formats, usually pushed by a specific event: a
+funder data-sharing requirement, a paper that needs an accompanying dataset, a departing
+postdoc who was the only person who understood the pipeline, or a reuse goal that the
+current file layout makes impossible. They are evaluating whether to hire outside help
+rather than assign a graduate student. They are technical but not software engineers, and
+they are deciding with real budget, often grant money with reporting obligations attached.
+The conversion they matter for is the consultation request.
+
+**Close second: funders and program officers.** NIH and foundation staff, and institutional
+partners, who reach the site to evaluate CatalystNeuro as a subaward recipient or
+infrastructure partner. They are checking legitimacy and track record rather than shopping.
+Every page must survive that scrutiny even when it is written for a PI, which in practice
+means claims stay verifiable and the funded-project, publication, and portfolio evidence
+stays easy to reach.
+
+**Third: researchers and engineers arriving through the open-source ecosystem.** People who
+found NeuroConv, NWB Inspector, NWB GUIDE, or a guide, and who came for documentation or
+technical depth rather than for services. They are a real and growing source of traffic, and
+some of them are future clients or future hires, but their needs never outrank the first two
+audiences when the two conflict.
+
+## Product Purpose
+
+CatalystNeuro is a research software engineering consultancy for neurophysiology. It
+provides the data and software engineering expertise that academic labs generally lack in
+house, so that researchers can concentrate on science instead of data infrastructure. The
+work is concentrated in converting lab data to the Neurodata Without Borders (NWB) standard,
+publishing it on the DANDI Archive, professionalizing research software through packaging,
+testing, and documentation, and increasingly in applying AI to neuroscience workflows.
+
+The website is a marketing, portfolio, and content site. Its jobs, in priority order:
+
+1. Convert lab PIs and funders into a consultation request.
+2. Establish credibility through the portfolio: NWB conversions, funded projects,
+   publications, institutions, and testimonials.
+3. Showcase the open-source software the team builds and maintains.
+4. Publish blog content: technical articles, release notes, and team retreats.
+5. Recruit through openings, and introduce the team.
+
+Success is a booked consultation from a qualified lab, and a funder or partner who finishes
+an evaluation without needing to ask whether the organization is real.
+
+## Positioning
+
+The leading claim is **research software engineers for neuroscience**: published domain
+scientists who also practice production-grade software engineering. That is the combination
+academic labs and generalist development shops each lack, and it is what goes in a hero, a
+meta description, or a first impression when only one line fits.
+
+Three further claims are confirmed true and binding, and serve as the proof beneath the
+leading one. Future work may reorder or emphasize them but must not treat any as optional
+marketing language:
+
+- **CatalystNeuro maintains the standard itself.** The team are core contributors and
+  maintainers of NWB, NeuroConv, NWB Inspector, and NWB GUIDE, and work directly with the
+  DANDI Archive. They are not vendors who learned the format.
+- **The portfolio is public and verifiable.** 60+ labs, 30+ institutions, with public
+  repositories and dandisets attached to the conversions.
+- **Everything ships open source.** A for-profit organization that nonetheless releases all
+  software it develops under permissive licenses, so labs keep the work and take on no
+  vendor lock-in or licensing fees.
+
+## Operating Context
+
+- Evaluation is slow and evidence-driven. A PI or program officer typically leaves the site
+  to check a GitHub repository, a dandiset, or a paper, and then returns. Outbound links to
+  real artifacts are part of the conversion path, not leakage.
+- Money moves on grant cycles. Inquiries cluster around funding decisions, renewals, and
+  data-sharing deadlines, which means the site is often read months before any contract.
+- The primary conversion action is booking a call, currently a Calendly inline embed for a
+  free 30-minute consultation. Email is the secondary path.
+- Visitors read on desktop in an office or lab setting more often than on a phone, but
+  conference and mobile reading is real for blog and software pages.
+- The organization is international and remote, and the work is delivered through public
+  repositories and public archives rather than through a client portal.
+
+## Capabilities and Constraints
+
+- **Stack:** Astro, static-first. Every route is a real pre-rendered HTML page. Tailwind CSS
+  v4 with a custom design system expressed as `@theme` tokens in `src/styles/global.css`.
+  Shiki for build-time syntax highlighting, with no client-side highlighting JS.
+- **Interactivity budget:** small islands of vanilla JS only, for the mobile nav, blog
+  search, conversion and funded-project filters, the institutions "show more" control, and
+  blog galleries. There is no client framework, and adding one is a real cost.
+- **Fonts:** self-hosted variable fonts through `@fontsource-variable`. No external font CDN.
+- **Content model:** markdown content collections (`blog`, `conversions`, `software`,
+  `fundedProjects`, `openings`) plus `src/data/team.json`, `src/data/about.md`, and
+  `src/data/site-content.ts` for publications, institutions, partners, featured articles,
+  testimonials, homepage copy, and filter vocabularies. `SPEC.md` is the authoritative
+  content and structure specification and should be updated when structure changes.
+- **Blog galleries** use HTML-comment markers expanded at build time by
+  `src/plugins/remark-galleries.mjs`. Folder names must match on-disk paths verbatim,
+  including spaces and existing typos.
+- **Hosting and integrations:** Netlify. Newsletter through Netlify Forms with a `/success`
+  route, consultation through a Calendly inline embed, video through YouTube embeds, sitemap
+  through `@astrojs/sitemap`. No CSP is currently set.
+- **Assets** live in `public/images/` and are served natively, with a one-year immutable
+  cache header. Roughly 220 image files plus PDFs, including large retreat photo sets.
+- **Terminology is domain-specific and must stay exact:** NWB (Neurodata Without Borders),
+  DANDI Archive, dandiset, NeuroConv, NWB Inspector, NWB GUIDE, neurodata extension (NDX),
+  spike sorting, electrophysiology, calcium imaging, fiber photometry, pose estimation.
+  These are the words the audience searches with and evaluates by. Do not soften them into
+  general-audience paraphrase.
+
+## Brand Commitments
+
+- Name: **CatalystNeuro**, one word. Canonical URL `https://catalystneuro.com`.
+- Logo: the CATALYST NEURO wordmark with the circular CN monogram. Carried at
+  `public/images/logo.png`.
+- Palette anchors: navy `#101642` and blue `#1466A7`. These are fixed brand values.
+- Contact email `info@catalystneuro.com`. Mailing address CatalystNeuro, 150 E B St Lbby
+  #1810 SMB#45673, Casper, WY 82601.
+- GitHub org `https://github.com/catalystneuro`. LinkedIn
+  `https://www.linkedin.com/company/catalyst-neuro`. Consultation booking
+  `https://calendly.com/ben-dichter`.
+- **Voice:** measured, expository, and plainly stated. Full explanatory paragraphs with
+  clear topic sentences rather than punchy fragments or aphorisms. Honest and
+  non-promotional, especially when comparing against others' work, and willing to concede
+  trade-offs. Section headings name the topic rather than making a joke about it.
+- **No em dashes anywhere in site copy.** Use commas, colons, parentheses, or separate
+  sentences instead. Verify before shipping copy.
+
+## Evidence on Hand
+
+Real, on hand, and citable:
+
+- **62 lab conversion entries** in `src/content/nwb-conversions/`, each with institution,
+  species, methods, and in most cases public GitHub repositories and DANDI dandisets. 31 of
+  the 62 carry dandiset links.
+- **14 funded projects** in `src/content/funded-projects/`, including NIH and foundation
+  grants, with status and start dates.
+- **4 peer-reviewed publications** (`src/data/site-content.ts`): the NeuroConv SciPy
+  Proceedings paper (2025), the Scientific Data paper on LLM tools for DANDI analysis
+  (2025), the Neurosift JOSS paper (2024), and the eLife NWB ecosystem paper (2022).
+- **30 institution logos** and **6 partner logos** (NIH, Allen Institute, Kavli Foundation,
+  Michael J. Fox Foundation, Simons Foundation, MIT) in `public/images/`.
+- **2 external features**, both in *The Transmitter*, by Benjamin Dichter.
+- **16 software and guide entries**: 4 core tools, 4 neurodata extensions, 6 analysis
+  packages, 2 guides.
+- **10 blog posts**, including technical articles and four annual team retreat posts with
+  large real photo libraries (`public/images/retreat-*`, roughly 137 photographs).
+- **14 team members** with real headshots for the 8 active members. Alumni intentionally
+  have no photo.
+
+Absences that future work must not paper over or invent around:
+
+- **There is exactly one testimonial** (Dr. Thomas Clandinin, Stanford). Do not fabricate
+  additional quotes, and do not design a layout that requires three to look finished.
+- **There are no AI case studies.** The AI in neuroscience line may cite the 2025 Scientific
+  Data paper on LLM tools for DANDI as real published evidence. Beyond that publication it
+  is a stated service offering, and no client AI engagement may be implied.
+- **Both job openings are currently disabled**, so `/openings` shows an empty state. The
+  empty state is the normal condition, not an edge case.
+- No pricing, no client logos beyond the institution and partner sets already on hand, and
+  no benchmark or performance claims exist. Do not create them.
+
+## Product Principles
+
+1. **Evidence over assertion.** Every credibility claim on this site should be one click
+   from something a skeptical PI or program officer can verify: a repository, a dandiset, a
+   paper, a grant. When a claim cannot be linked to an artifact, weaken the claim rather
+   than dressing it up.
+2. **The consultation is the conversion, and it is slow.** Design for a visitor who will
+   read, leave to check the work, and return weeks later. Depth and durability of
+   information beat urgency tactics, which this audience actively distrusts.
+3. **Speak the field's language exactly.** Domain terminology is a credibility signal to
+   this audience, not jargon to be smoothed away. Precision reads as competence.
+4. **Open source is structural, not a feature bullet.** The portfolio, the software pages,
+   and the outbound links to public repositories are the same argument told three ways: the
+   client keeps everything, and the record is public.
+5. **Leave room for AI in neuroscience to grow.** The AI service line is expanding and
+   should be able to become a first-class area with its own evidence over time, rather than
+   remaining permanently one card on the homepage. Build structures that can absorb that
+   growth without a redesign, but do not stage evidence that does not yet exist.
+
+## Accessibility & Inclusion
+
+Target **WCAG 2.2 AA** as the floor. This standard was chosen during init rather than
+supplied by the user: a substantial share of the work is federally funded and evaluated by
+institutional partners, so AA is the level a funder or university would expect, and it is
+the reasonable default for an organization whose entire argument is that data and tools
+should be usable by everyone.
+
+In practice that means: text contrast at or above 4.5:1 (3:1 for large text and meaningful
+non-text elements), a visible and unambiguous focus indicator on every interactive element,
+full keyboard operation of all interactive islands (mobile nav, blog search, conversion and
+funded-project filters, the institutions expander, and the blog gallery carousels),
+`prefers-reduced-motion` honored by any motion, correct heading order on every page, and
+real alternative text on the substantive imagery including team headshots, institution
+logos, and blog banners. Decorative retreat photography may use empty alt text.

--- a/src/data/about.md
+++ b/src/data/about.md
@@ -32,7 +32,7 @@ We partner with individual labs to develop customized solutions, offering both v
 
 ### Software Engineering
 
-We help labs integrate their existing analysis, visualization, and data management tools with the broader open science ecosystem via NWB and DANDI. Our team professionalizes research software through proper packaging, comprehensive testing, and thorough documentation—transforming prototype code into reliable, maintainable tools. We also design reproducible workflows for data processing and analysis, ensuring that research outputs can be shared and replicated across the scientific community.
+We help labs integrate their existing analysis, visualization, and data management tools with the broader open science ecosystem via NWB and DANDI. Our team professionalizes research software through proper packaging, comprehensive testing, and thorough documentation, transforming prototype code into reliable, maintainable tools. We also design reproducible workflows for data processing and analysis, ensuring that research outputs can be shared and replicated across the scientific community.
 
 ### AI in Neuroscience
 

--- a/src/data/site-content.ts
+++ b/src/data/site-content.ts
@@ -14,8 +14,8 @@ export const HERO = {
   ],
 };
 
-// STATS are derived from the content collections at build time — see
-// src/pages/index.astro. Only the labels live here.
+// STATS are derived from the content collections at build time (see
+// src/pages/index.astro). Only the labels live here.
 export const STAT_LABELS = {
   labs: "Research labs supported",
   projects: "Grant-funded projects",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -33,7 +33,9 @@
   --color-line-soft: #ecf1f8;
 
   --color-ink-muted: #55607a;
-  --color-ink-soft: #7c86a0;
+  /* Tertiary text. Set for WCAG AA at the small sizes it is used at (stamps,
+     dates, counts, pagination): 4.86:1 on white, 4.56:1 on paper. */
+  --color-ink-soft: #68718b;
 
   --font-display: "Figtree Variable", Figtree, system-ui, sans-serif;
   --font-sans: "Inter Variable", Inter, system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
Two separable pieces of work, kept as two commits so the code change can be reviewed on its own.

## The code change

`--color-ink-soft` was `#7c86a0`, which measures 3.64:1 against white and 3.41:1 against the paper background. That token is applied at 0.7rem to 0.85rem in nine places (post dates, portfolio card date stamps, result counts, pagination, card footers, blog card meta, funder labels, the publications journal line, and featured article footers), so every one of its text uses sat below the 4.5:1 that WCAG 2.2 AA asks for at that size. None of the nine sit on a dark background, so darkening the token was safe everywhere it appears.

It is now `#68718b`, which clears AA on both grounds at 4.86:1 and 4.56:1. The lighter `#6b7590` was tried first and rejected: it cleared white at 4.59:1 but still failed the paper background at 4.31:1. Cool Paper is slightly lighter than white and costs about 0.3 of a point, which makes it the binding constraint rather than white.

The visible tradeoff is that the gap between Muted Ink and Soft Ink narrows from 2.65 to 1.43 points of contrast ratio. The three steps stay ordered and the portfolio card still reads as dark heading, mid description, light metadata, but this is the part worth a second opinion. If the metadata now feels too present, the right correction is size or weight rather than going back to a failing color.

The same commit replaces two em dashes, one in the About page's Software Engineering paragraph and one in a code comment.

## The documentation

`PRODUCT.md` records durable product truth: the audience priority (lab PIs first, funders a close second), the positioning and the claims supporting it, the evidence actually on hand, and the absences that future work must not invent around. The last point is the useful one: there is exactly one testimonial, there are no AI case studies beyond the 2025 Scientific Data paper, and both job openings are disabled so the empty state is the normal condition. The WCAG 2.2 AA target that motivated the fix above is recorded there.

`DESIGN.md` documents the visual system the Astro rebuild already established, under the name "The Live Recording". It covers the palette and each color's role, the three type faces and what governs each, the layout and spacing model, the flat-at-rest elevation doctrine, and the component specifications. It describes what the code does rather than proposing anything new.

`.impeccable/design.json` is the machine-readable sidecar holding tonal ramps, shadow and motion tokens, breakpoints, and self-contained component snippets. `.impeccable/live/config.json` configures live iteration mode, and session journals under `.impeccable/live/sessions` are local recovery state and gitignored.

## Verification

`npm run build` completes cleanly at 113 pages. The built CSS contains `ink-soft:#68718b`, the old value appears nowhere in `dist/`, and the About page renders the corrected punctuation. All contrast figures above were computed rather than estimated.

Nothing here changes layout, content, or behavior. The only rendered differences are the shade of nine small text elements and one comma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)