### PR TITLE
Shorten the GuPPy description

### DIFF
--- a/src/content/software/guppy.md
+++ b/src/content/software/guppy.md
@@ -1,6 +1,6 @@
 ---
 name: GuPPy
-description: Guided Photometry Analysis in Python, a free and open-source fiber photometry data analysis tool developed in collaboration with the Lerner Lab at Northwestern University. GuPPy provides researchers with a comprehensive pipeline for processing and analyzing fiber photometry data, including artifact correction, signal normalization, peak detection, and visualization capabilities. The Lerner Lab leads the scientific development and analysis features, while our team at CatalystNeuro focuses on the software engineering foundation that makes GuPPy sustainable and accessible. We are streamlining installation and distribution, implementing automated quality assurance, improving reliability and error handling, and enabling seamless data sharing across research platforms.
+description: Guided Photometry Analysis in Python, a free and open-source fiber photometry analysis tool developed in collaboration with the Lerner Lab at Northwestern University. GuPPy covers artifact correction, signal normalization, peak detection, and visualization. The Lerner Lab leads the scientific development, while our team at CatalystNeuro works on the software engineering foundation that makes GuPPy sustainable and accessible, including installation and distribution, automated quality assurance, reliability and error handling, and data sharing across research platforms.
 status: Active
 type: analysis
 image: /images/software/guppy_logo.png


### PR DESCRIPTION
Trims the GuPPy entry on the software page from 98 words to 74, a cut of about a quarter.

Almost all of the reduction comes from framing rather than content. "Provides researchers with a comprehensive pipeline for processing and analyzing fiber photometry data, including" becomes "covers", the four parallel "we are streamlining / implementing / improving / enabling" clauses collapse into a single list, and "capabilities" and "seamless" are gone. Every named feature, both institutions, and the division of labor between the Lerner Lab and CatalystNeuro are unchanged.

The one substantive cut is "and analysis features" from the sentence on what the Lerner Lab leads, since the following clause about our engineering work already draws that line.

`npm run build` passes and the card renders correctly on `/analysis-software/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)