### PR TITLE
Publish the ASAP project page at /funded-projects/asap-nwb-adoption

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,5 +13,13 @@
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
+# The ASAP funded-project page was published under a slug derived from the
+# program's full name. The title, and therefore the slug, is back to
+# "ASAP NWB Adoption", so keep the old address working.
+[[redirects]]
+  from = "/funded-projects/aligning-science-across-parkinson-s"
+  to = "/funded-projects/asap-nwb-adoption"
+  status = 301
+
 # Astro emits real static pages for every route, so no SPA catch-all is needed.
 # A 404.html is generated automatically for unmatched paths.

--- a/src/content/funded-projects/mjff-asap.md
+++ b/src/content/funded-projects/mjff-asap.md
@@ -1,5 +1,5 @@
 ---
-title: "Aligning Science Across Parkinson's"
+title: "ASAP NWB Adoption"
 funder: "Michael J. Fox Foundation"
 status: "active"
 startDate: "2023-01-01"

--- a/src/data/site-content.ts
+++ b/src/data/site-content.ts
@@ -255,10 +255,9 @@ export const RESEARCH_AREAS = [
 ];
 
 // Reconcile funded-project titles with conversion `funded_project` values,
-// for the few projects whose conversions reference a shorter name. (The ASAP
-// project uses its full name "Aligning Science Across Parkinson's" on both
-// sides, so it needs no alias.)
+// for the few projects whose conversions reference a different name.
 export const FUNDED_PROJECT_ALIASES: Record<string, string> = {
   "NYU Librarians NWB Adoption": "NYU Librarians",
   "Ripple U19 NWB Adoption": "Ripple U19",
+  "ASAP NWB Adoption": "Aligning Science Across Parkinson's",
 };


### PR DESCRIPTION
Changes the funded-project title from "Aligning Science Across Parkinson's" back to "ASAP NWB Adoption". The route slug is derived from the title, so the page moves from `/funded-projects/aligning-science-across-parkinson-s/` to `/funded-projects/asap-nwb-adoption/`.

Fourteen conversion entries name this project in their `funded_project` field, and they keep using the program's full name. Rather than editing all fourteen, this adds one entry to `FUNDED_PROJECT_ALIASES`, which is what that map exists for. The NYU Librarians and Ripple U19 pages already work the same way, with an "X NWB Adoption" title and conversions that reference a shorter name.

Verified in the build: the project page lists all fourteen conversions, and a conversion page such as Talia Lerner's links to `/funded-projects/asap-nwb-adoption` while still displaying the full program name as the link label.

Since the old address is currently live, this also adds a 301 in `netlify.toml`. It is the first redirect in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)