### PR TITLE
Add Dandiset 001172 to the Higley Lab entry

### DIFF
--- a/src/content/nwb-conversions/yale-higley-lab.md
+++ b/src/content/nwb-conversions/yale-higley-lab.md
@@ -4,6 +4,9 @@ institution: "Yale University"
 description: "Developed NWB conversion tools for the Higley lab's neurophysiology datasets, including the Lohani 2022 study which combines behavioral measurements with neural recordings. The conversion pipeline handles multi-modal data integration and implements custom behavioral interfaces for specialized experimental protocols."
 tags: ["electrophysiology", "behavioral tracking"]
 github: "https://github.com/catalystneuro/higley-lab-to-nwb"
+dandi:
+  - url: "https://dandiarchive.org/dandiset/001172"
+    name: "001172: Dual-color mesoscopic imaging of both ACh and calcium across the neocortex of awake mice"
 date: "2023-09"
 funded_project: "Aligning Science Across Parkinson's"
 species: Mouse


### PR DESCRIPTION
Adds [Dandiset 001172](https://dandiarchive.org/dandiset/001172/), "Dual-color mesoscopic imaging of both ACh and calcium across the neocortex of awake mice," to the Yale Higley Lab conversion entry. The page had no `dandi` field before, so this is its first published dataset link.

The title is taken from the archive's metadata for version 0.260129.0829 rather than typed by hand, and I confirmed the dandiset is the right lab's: Michael Higley and Jessica Cardin are listed as contributors, with Sweyta Lohani first, which matches the Lohani study named in the entry's description.

Uses the list form of the `dandi` field with an explicit `name`, the same shape as the Baylor Reimer entry, so the link renders with the dataset title instead of a bare identifier.

One thing to consider separately: the "Publication on DANDI" section of this entry says the upload runs in embargo mode until the preprint is accepted. That dataset is now public, so that paragraph may be due for an update. I left it alone here since it is a different change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)