### PR TITLE
Retitle the Pareto frontier post

### DIFF
--- a/public/js/pareto-frontier-charts.js
+++ b/public/js/pareto-frontier-charts.js
@@ -1,4 +1,4 @@
-/* Interactive charts for "The Moving Pareto Frontier of Cost per Task".
+/* Interactive charts for "The Falling Cost of LLM Intelligence".
    Self-contained: data, rendering, tooltips. Styled to the site palette. */
 (function () {
   'use strict';

--- a/src/content/blog/pareto-frontier-cost-per-task.md
+++ b/src/content/blog/pareto-frontier-cost-per-task.md
@@ -1,5 +1,5 @@
 ---
-title: "The Moving Pareto Frontier of Cost per Task for LLMs"
+title: "The Falling Cost of LLM Intelligence"
 date: "2026-08-19"
 description: "Progress in LLMs is usually reported as what the best model can do. This post uses Artificial Analysis's measured cost per task to trace the other direction of progress, how cheaply a given level of capability can be bought, and argues that it matters just as much: the ceiling unlocks new kinds of tasks, while the falling floor unlocks tasks that need to be done thousands of times."
 image: "/images/blog/pareto-frontier-banner.png"


### PR DESCRIPTION
Retitles the post from "The Moving Pareto Frontier of Cost per Task for LLMs" to "The Falling Cost of LLM Intelligence", to match the application-focused opening from #103 and keep jargon out of the title. The slug and URL are unchanged; the Pareto frontier terminology remains in the description and keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpr7Ki53KD8ACfRKE8yBch