### PR TITLE
Add gray model points to the tier records chart

### DIFF
--- a/public/js/pareto-frontier-charts.js
+++ b/public/js/pareto-frontier-charts.js
@@ -203,6 +203,18 @@
     svg.append(svgEl('line', { x1: M.l, x2: M.l, y1: M.t, y2: H - M.b, stroke: C.axis, 'stroke-width': 1 }));
 
     var pts = [];
+    models.forEach(function (m) {
+      if (Date.parse(m.date + 'T00:00:00Z') < x0) return;
+      var x = X(m.date), y = Y(m.mcost);
+      dot(svg, x, y, 3.5, m.retired ? C.retired : C.deemph, m.retired);
+      pts.push({ x: x, y: y, rows: function () {
+        var d1 = el('div', 'pfc-tt-name'); d1.textContent = m.name;
+        var d2 = el('div'); var s = el('span', 'pfc-tt-val'); s.textContent = fmt$(m.mcost);
+        d2.append(s, ' per task at Index ' + m.iq.toFixed(1));
+        var d3 = el('div', null, m.creator + ' \u00b7 released ' + m.date + (m.retired ? ' \u00b7 retired' : ''));
+        return [d1, d2, d3];
+      }});
+    });
     var endLabels = [];
     TIERS.forEach(function (tier, i) {
       var recs = DATA.tier_cost[tier];

--- a/src/content/blog/pareto-frontier-cost-per-task.md
+++ b/src/content/blog/pareto-frontier-cost-per-task.md
@@ -68,7 +68,7 @@ The records view tracks the cheapest measured cost per task achieved by any rele
   <div id="pfc-records"></div>
   <div class="pfc-legend" id="pfc-records-legend"></div>
   <noscript><img src="/images/blog/pareto-tier-records.svg" alt="Running minimum measured cost per task at each Intelligence Index tier, by release date" /></noscript>
-  <figcaption>Each step is a released model that set a new low for its tier; hollow markers are retired models. A tier's line begins when the first model with measured cost crosses that Intelligence Index threshold. Costs reflect current prices (see caveats).</figcaption>
+  <figcaption>Gray points are all models released since July 2025 at their measured cost per task, regardless of Intelligence Index; hover for the model and its score. Each colored step is a released model that set a new low for its tier; hollow markers are retired models. A tier's line begins when the first model with measured cost crosses that Intelligence Index threshold. Costs reflect current prices (see caveats).</figcaption>
 </figure>
 
 | Tier | First measured crossing | Cost collapse | Halving time |


### PR DESCRIPTION
Figure 2 (cheapest cost per task by Intelligence Index tier) now shows all 127 models released since July 2025 as gray points at their release date and measured cost, beneath the tier record lines, matching the treatment in Figure 1. Hovering a gray point shows the model, its cost, Intelligence Index, release date, and retired status. The caption is updated accordingly. The static noscript SVG is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpr7Ki53KD8ACfRKE8yBch