### PR TITLE
Tint points by release window and animate the frontier chart

### DIFF
--- a/public/js/pareto-frontier-charts.js
+++ b/public/js/pareto-frontier-charts.js
@@ -60,12 +60,13 @@
       var sx = svg.viewBox.baseVal.width / r.width;
       var mx = (ev.clientX - r.left) * sx, my = (ev.clientY - r.top) * sx;
       var best = null, bd = Infinity;
-      points.forEach(function (p) {
+      var visible = points.filter(function (p) { return p.snap === undefined || p.snap <= anim.stage; });
+      visible.forEach(function (p) {
         var d = Math.hypot(p.x - mx, p.y - my);
         if (d < bd) { bd = d; best = p; }
       });
       if (!best || bd > 40) { hideTip(); return; }
-      var group = points.filter(function (p) { return Math.hypot(p.x - best.x, p.y - best.y) < 3; });
+      var group = visible.filter(function (p) { return Math.hypot(p.x - best.x, p.y - best.y) < 3; });
       var rows = [];
       group.forEach(function (p) { rows = rows.concat(p.rows()); });
       showTip(box, best.x / sx, best.y / sx, rows);
@@ -80,10 +81,36 @@
   }
 
   // ---- chart 1: intelligence vs cost, frontier every two months ----
+  var anim = { stage: SNAPS.length - 1, paused: false, timer: null, groups: [] };
+  var STEP_MS = 1100, HOLD_MS = 6000;
+  function applyStage() {
+    anim.groups.forEach(function (gs, i) {
+      gs.forEach(function (g) { g.setAttribute('display', i <= anim.stage ? 'inline' : 'none'); });
+    });
+    var cap = document.getElementById('pfc-frontier-stage');
+    if (cap) cap.textContent = 'Frontier as of ' + SNAPS[anim.stage][1];
+  }
+  function tick() {
+    clearTimeout(anim.timer);
+    if (anim.paused) return;
+    anim.stage = anim.stage >= SNAPS.length - 1 ? 0 : anim.stage + 1;
+    applyStage();
+    hideTip();
+    anim.timer = setTimeout(tick, anim.stage === SNAPS.length - 1 ? HOLD_MS : STEP_MS);
+  }
+  function setPaused(p) {
+    anim.paused = p;
+    var b = document.getElementById('pfc-frontier-toggle');
+    if (b) { b.textContent = p ? 'Play' : 'Pause'; b.setAttribute('aria-pressed', p ? 'true' : 'false'); }
+    if (p) clearTimeout(anim.timer);
+    else anim.timer = setTimeout(tick, anim.stage === SNAPS.length - 1 ? HOLD_MS : STEP_MS);
+  }
+
   function renderFrontier() {
     var box = document.getElementById('pfc-frontier');
     if (!box) return;
     box.replaceChildren();
+    anim.groups = SNAPS.map(function () { return []; });
     var W = Math.max(320, Math.min(880, box.clientWidth)), H = 440;
     var M = { l: 56, r: 16, t: 12, b: 42 };
     var svg = frame(box, W, H, M, 'Intelligence Index versus cost per task with Pareto frontier lines every two months');
@@ -109,15 +136,25 @@
     yt.textContent = 'Artificial Analysis Intelligence Index'; svg.append(yt);
 
     var pts = [];
+    function windowIndex(date) {
+      for (var i = 0; i < SNAPS.length; i++) if (date <= SNAPS[i][0]) return i;
+      return SNAPS.length - 1;
+    }
     models.forEach(function (m) {
       var x = X(m.mcost), y = Y(m.iq);
-      dot(svg, x, y, 3.5, C.deemph, m.open);
-      pts.push({ x: x, y: y, rows: function () {
+      var wi = windowIndex(m.date);
+      var g = svgEl('g', { opacity: 0.45 });
+      dot(g, x, y, 3.5, C.snap[wi], m.open);
+      svg.append(g);
+      anim.groups[wi].push(g);
+      pts.push({ x: x, y: y, snap: wi, rows: function () {
         var d1 = el('div', 'pfc-tt-name'); d1.textContent = m.name;
         var d2 = el('div'); var s = el('span', 'pfc-tt-val'); s.textContent = fmt$(m.mcost);
         d2.append(s, ' per task at Index ' + m.iq.toFixed(1));
         var d3 = el('div', null, m.creator + ' \u00b7 ' + (m.open ? 'open weights' : 'proprietary') + ' \u00b7 released ' + m.date + (m.retired ? ' \u00b7 retired' : ''));
-        return [d1, d2, d3];
+        var d4 = el('div', 'pfc-tt-row'); var kd = el('span', 'pfc-tt-key'); kd.style.borderTopColor = C.snap[wi];
+        d4.append(kd, 'in the ' + SNAPS[wi][1].replace(' (today)', '') + ' window');
+        return [d1, d2, d3, d4];
       }});
     });
 
@@ -135,11 +172,14 @@
         if (j < fr.length - 1) d += ' H ' + X(fr[j + 1].mcost) + ' V ' + Y(fr[j + 1].iq);
       });
       d += ' H ' + (W - M.r);
-      svg.append(svgEl('path', { d: d, fill: 'none', stroke: color, 'stroke-width': i === SNAPS.length - 1 ? 3 : 2, 'stroke-linejoin': 'round', 'stroke-linecap': 'round' }));
+      var sg = svgEl('g', {});
+      sg.append(svgEl('path', { d: d, fill: 'none', stroke: color, 'stroke-width': i === SNAPS.length - 1 ? 3 : 2, 'stroke-linejoin': 'round', 'stroke-linecap': 'round' }));
+      svg.append(sg);
+      anim.groups[i].push(sg);
       fr.forEach(function (p) {
         var x = X(p.mcost), y = Y(p.iq);
-        dot(svg, x, y, 4, color, p.open);
-        pts.push({ x: x, y: y, rows: function () {
+        dot(sg, x, y, 4, color, p.open);
+        pts.push({ x: x, y: y, snap: i, rows: function () {
           var d1 = el('div', 'pfc-tt-name'); d1.textContent = p.name;
           var d2 = el('div', 'pfc-tt-row');
           var kd = el('span', 'pfc-tt-key'); kd.style.borderTopColor = color;
@@ -152,6 +192,15 @@
     });
     box.append(svg);
     attachHover(box, svg, pts);
+    var ctl = el('div', 'pfc-controls');
+    var stageLabel = el('span', 'pfc-stage'); stageLabel.id = 'pfc-frontier-stage';
+    var btn = document.createElement('button');
+    btn.type = 'button'; btn.className = 'pfc-btn'; btn.id = 'pfc-frontier-toggle';
+    btn.addEventListener('click', function () { setPaused(!anim.paused); });
+    ctl.append(stageLabel, btn);
+    box.append(ctl);
+    applyStage();
+    setPaused(anim.paused);
 
     var legend = document.getElementById('pfc-frontier-legend');
     if (legend) {
@@ -252,6 +301,7 @@
     }
   }
 
+  if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) anim.paused = true;
   function renderAll() { renderFrontier(); renderRecords(); }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', renderAll);
   else renderAll();

--- a/src/content/blog/pareto-frontier-cost-per-task.md
+++ b/src/content/blog/pareto-frontier-cost-per-task.md
@@ -22,6 +22,10 @@ keywords: ["LLM", "Pareto frontier", "cost per task", "Artificial Analysis", "In
 .pfc-tt-row { display: flex; align-items: center; gap: 0.45rem; }
 .pfc-tt-key { width: 12px; border-top: 2.5px solid; border-radius: 2px; flex: none; display: inline-block; }
 .pfc-figure img { width: 100%; height: auto; }
+.pfc-controls { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; margin-top: 0.4rem; }
+.pfc-stage { font-size: 0.82rem; font-weight: 600; color: var(--color-navy); }
+.pfc-btn { font: inherit; font-size: 0.78rem; padding: 0.25rem 0.7rem; border: 1px solid var(--color-line); border-radius: 6px; background: var(--color-surface); color: var(--color-navy); cursor: pointer; min-width: 4.2rem; }
+.pfc-btn:hover { border-color: var(--color-navy); }
 .pfc-pelicans { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.7rem; }
 .pfc-pelicans figure { margin: 0; }
 .pfc-pelicans img { width: 100%; aspect-ratio: 4 / 3; height: auto; object-fit: contain; background: #fff; border-radius: 6px; border: 1px solid var(--color-line-soft); }
@@ -68,13 +72,13 @@ Cost per token is easily available, but different models can use a very differen
 
 ## How the Frontier Has Moved
 
-The chart below plots intelligence against measured cost per task and traces the Pareto frontier, the cheapest way to reach each intelligence level, as it stands today and as it stood at two month intervals over the past year, using each model's release date to reconstruct what was available. Hover any point for the model behind it.
+The chart below plots intelligence against measured cost per task and traces the Pareto frontier, the cheapest way to reach each intelligence level, as it stands today and as it stood at two month intervals over the past year, using each model's release date to reconstruct what was available. The chart builds up one frontier at a time, pauses on the full picture, and repeats; use the button to stop it. Hover any point for the model behind it.
 
 <figure class="pfc-figure">
   <div id="pfc-frontier"></div>
   <div class="pfc-legend" id="pfc-frontier-legend"></div>
   <noscript><img src="/images/blog/pareto-frontier-bimonthly.svg" alt="Intelligence Index versus cost per task with Pareto frontier lines every two months from August 2025 to August 2026" /></noscript>
-  <figcaption>Intelligence Index against measured cost per Intelligence Index task (log scale). Gray points are all 137 measured models at their last measured cost. Hollow points, both gray and colored, are open weights models; filled points are proprietary. Hover a point for its details, including whether Artificial Analysis has retired it from live benchmarking. Each line traces the cheapest way to reach a given Intelligence Index among models released by the snapshot date; markers are the frontier models themselves. Where successive frontiers share a segment, the older line is drawn on top, so a newer line is visible only where the frontier actually moved. Models whose pages no longer carry a measured cost (o3 and GPT-5.3 Codex among them) are absent (see caveats).</figcaption>
+  <figcaption>Intelligence Index against measured cost per Intelligence Index task (log scale). Small points are all 137 measured models at their last measured cost, tinted by the two month window in which they were released (models from before August 2025 are grouped with the August 2025 window). Hollow points, both small and large, are open weights models; filled points are proprietary. Hover a point for its details, including whether Artificial Analysis has retired it from live benchmarking. Each line traces the cheapest way to reach a given Intelligence Index among models released by the snapshot date; markers are the frontier models themselves. Where successive frontiers share a segment, the older line is drawn on top, so a newer line is visible only where the frontier actually moved. Models whose pages no longer carry a measured cost (o3 and GPT-5.3 Codex among them) are absent (see caveats).</figcaption>
 </figure>
 
 Each successive frontier sits above and to the left of the last: more intelligence at the same cost, or the same intelligence for less. The pace of that movement is accelerating. Through the second half of 2025 the frontier inched forward: only two small bumps between August and October, and a single one between October and December. The February and April frontiers each moved a large part of the curve, and the last two snapshots have replaced the frontier almost entirely, with ten of the eleven June frontier models new since April and fifteen of today's sixteen new since June.


### PR DESCRIPTION
Two changes to Figure 1.

**Window-tinted points.** The small background points are now drawn in the color of the two-month snapshot window in which the model was released, at reduced opacity so the frontier lines still stand out. Models released before August 2025 are grouped with the August 2025 window. Tooltips name the window. Hollow vs filled still encodes open weights vs proprietary.

**Animation.** The chart builds up one snapshot at a time (frontier line, its markers, and that window's background points), about 1.1 s per step, holds the complete plot for 6 s, and repeats. A label under the chart shows the current snapshot and a Pause/Play button stops and resumes it. The animation starts paused on the full plot when the viewer has `prefers-reduced-motion` set. Hover tooltips only consider points visible at the current stage. The intro sentence for the chart and the caption are updated.

The static noscript SVG is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpr7Ki53KD8ACfRKE8yBch