### PR TITLE
Add About the Author to the Pareto frontier post

### DIFF
--- a/src/content/blog/pareto-frontier-cost-per-task.md
+++ b/src/content/blog/pareto-frontier-cost-per-task.md
@@ -131,4 +131,17 @@ The practical consequence is that the set of problems worth attempting with a mo
 
 *Model metadata pulled from the Artificial Analysis free API, and measured cost per task scraped from the model pages on artificialanalysis.ai, on August 19, 2026. Corrections welcome.*
 
+## About the Author
+
+<div style="display: flex; align-items: flex-start; gap: 20px; margin-top: 20px;">
+<img src="/images/team/benjamin_dichter.png" alt="Ben Dichter" style="width: 150px; height: 150px; border-radius: 50%; object-fit: cover;" />
+<div>
+
+**Ben Dichter, PhD** is the Founder of CatalystNeuro. He received his Ph.D. in Bioengineering from the UC Berkeley – UCSF Joint Program in Bioengineering, in Dr. Edward Chang's lab. There he used electrocorticography (ECoG) to study the neural control of speech in humans. Much of this work focused on how we control the pitch of our voice when we speak and sing. He is now a data scientist consultant for neuroscience labs, focusing on building systems for sharing of data and analyses.
+
+[GitHub](https://github.com/bendichter) • [Twitter](https://twitter.com/bendichter) • [Website](http://bendichter.com) • [ORCID](https://orcid.org/0000-0001-5725-6910)
+
+</div>
+</div>
+
 <script src="/js/pareto-frontier-charts.js" defer></script>


### PR DESCRIPTION
Appends the same About the Author block used in the virtual data standards post, after the data note and before the chart script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpr7Ki53KD8ACfRKE8yBch