### PR TITLE
Link the LLM Cost Frontier dashboard from the navigation

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -30,6 +30,7 @@ export const NAV = [
       { label: "NWB Software", href: "/nwb-software" },
       { label: "Analysis Software", href: "/analysis-software" },
       { label: "Guides", href: "/guides" },
+      { label: "LLM Cost Frontier", href: "/llm-cost-frontier" },
     ],
   },
   {
@@ -62,6 +63,7 @@ export const FOOTER = [
       { label: "Funded Projects", href: "/funded-projects" },
       { label: "NWB Software", href: "/nwb-software" },
       { label: "Analysis Software", href: "/analysis-software" },
+      { label: "LLM Cost Frontier", href: "/llm-cost-frontier" },
     ],
   },
   {


### PR DESCRIPTION
Adds "LLM Cost Frontier" to the Software dropdown in the header (after Guides) and to the Resources column of the footer, so the dashboard is reachable from every page, not only from the blog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lpr7Ki53KD8ACfRKE8yBch