### PR TITLE
Sync frontier data on dispatch from the pipeline instead of a cron

### DIFF
--- a/.github/workflows/sync-llm-frontier.yml
+++ b/.github/workflows/sync-llm-frontier.yml
@@ -1,14 +1,12 @@
 name: Sync LLM cost frontier data
 
 # The pipeline that produces these files lives in catalystneuro/llm-cost-frontier
-# and refreshes them nightly at 06:00 UTC. This job copies the published
-# artifacts into the site so they are served from catalystneuro.com, and the
-# commit triggers a Netlify build.
+# and refreshes them nightly at 06:00 UTC. Its update workflow dispatches this
+# one whenever it pushes new data. This job copies the published artifacts into
+# the site so they are served from catalystneuro.com, and the commit triggers a
+# Netlify build.
 
 on:
-  schedule:
-    # An hour after the source repository updates.
-    - cron: "0 7 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Companion to catalystneuro/llm-cost-frontier#4: the pipeline's update workflow now dispatches this sync directly whenever it pushes new data, so the staggered 07:00 UTC cron is removed and the site republishes minutes after the data lands rather than up to an hour later. `workflow_dispatch` stays, so manual runs from the Actions tab still work.

Merge order: set the `WEBSITE_DISPATCH_TOKEN` secret described in the pipeline PR and merge it first; without that, removing the cron here means the site only syncs when run by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014827duyb34XeyPz1XF4mmt