### PR TITLE
Stack the chart legends below the plots up to 950px

### DIFF
--- a/src/pages/llm-cost-frontier.astro
+++ b/src/pages/llm-cost-frontier.astro
@@ -121,7 +121,11 @@ import PageHeader from "../components/PageHeader.astro";
   /* Below this the side legend's fixed column squeezes the chart and sits
      mostly empty; stack it under the chart so the plot gets the full width.
      950px keeps the side layout only when the chart still gets ~700px. */
-  @media (max-width: 950px) { .pfc-side { flex-direction: column; } .pfc-legend-side { flex-direction: row; flex-wrap: wrap; border-left: 0; padding-left: 0; flex-basis: auto; } }
+  /* align-items must switch to stretch with the column direction: the base
+     rule's flex-start would size the chart div to its content, and an SVG
+     with width 100% has no intrinsic width, so the chart collapsed to the
+     300px replaced-element fallback and left the rest of the row empty. */
+  @media (max-width: 950px) { .pfc-side { flex-direction: column; align-items: stretch; } .pfc-legend-side { flex-direction: row; flex-wrap: wrap; border-left: 0; padding-left: 0; flex-basis: auto; } }
 </style>
 
 <script src="/js/llm-frontier-dashboard.js" defer></script>

--- a/src/pages/llm-cost-frontier.astro
+++ b/src/pages/llm-cost-frontier.astro
@@ -118,7 +118,10 @@ import PageHeader from "../components/PageHeader.astro";
   .pfc-side-chart { flex: 1 1 auto; min-width: 0; }
   .pfc-legend-side :global(.pfc-legend-title) { font-weight: 600; color: var(--color-navy); font-size: 0.82rem; margin-bottom: 0.1rem; }
   .pfc-legend-side { flex: 0 0 9.5rem; flex-direction: column; align-items: flex-start; gap: 0.45rem; margin-top: 0.6rem; padding-left: 1rem; border-left: 1px solid var(--color-line-soft); }
-  @media (max-width: 700px) { .pfc-side { flex-direction: column; } .pfc-legend-side { flex-direction: row; flex-wrap: wrap; border-left: 0; padding-left: 0; flex-basis: auto; } }
+  /* Below this the side legend's fixed column squeezes the chart and sits
+     mostly empty; stack it under the chart so the plot gets the full width.
+     950px keeps the side layout only when the chart still gets ~700px. */
+  @media (max-width: 950px) { .pfc-side { flex-direction: column; } .pfc-legend-side { flex-direction: row; flex-wrap: wrap; border-left: 0; padding-left: 0; flex-basis: auto; } }
 </style>
 
 <script src="/js/llm-frontier-dashboard.js" defer></script>


### PR DESCRIPTION
Fixes the empty space to the right of the dashboard charts at narrow window widths. Two changes, and the second is the actual root cause:

- **Stretch the stacked column.** The stacked layout inherited `align-items: flex-start` from the base rule, which in column direction sizes children to their content width. An SVG with `width: 100%` has no intrinsic width, so the chart div collapsed to the 300px replaced-element fallback and the rest of the figure sat empty to its right. This bug was present on phones all along. Verified live in the browser: with the column layout forced, the chart measured 300px in an 843px container before the fix and fills all 843px with `align-items: stretch`.
- **Stack the legends below the plots up to 950px.** Between about 700 and 950px the fixed side legend column squeezed the charts; the side layout now applies only above 950px, where the chart still gets about 700px of width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014827duyb34XeyPz1XF4mmt